### PR TITLE
Add CI and very basic tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: centos:7 # We support centos 6, but 7 already has a cpanm package
+    steps:
+      - checkout
+      - run: 'yum install --setopt=skip_missing_names_on_install=False -y perl-App-cpanminus gettext gcc epel-release'
+      - run: 'yum install --setopt=skip_missing_names_on_install=False -y dpkg-dev fakeroot'
+      - run: 'perl -V'
+      - run: 'cpanm --notest --installdeps .'
+      - run: 'yath'
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,1 @@
+requires 'Locale::gettext', '1.0';

--- a/cpanfile
+++ b/cpanfile
@@ -1,1 +1,6 @@
 requires 'Locale::gettext', '1.0';
+
+on test => sub {
+  requires 'Test2::V0', '0.000126';
+  requires 'Test2::Harness', '0.001099';
+};

--- a/t/001_version.t
+++ b/t/001_version.t
@@ -1,0 +1,6 @@
+use Test2::V0;
+
+plan 1;
+
+chomp(my $version_string = `./debbuild --version`);
+is($version_string, 'This is debbuild, version @VERSION@', 'Verify that debbuild --version runs');


### PR DESCRIPTION
Add CI to run tests.

Right now, there is only one very basic test, which verifies that `debbuild --version` works.

Substantially more work will need to be done before debbuild can get through the prep phase within the container. (We'll need to move much of the `%install` macro in debbuild.spec into a `make install` so that we can run it in the container.)