### PR TITLE
Introduce Makefile and configure script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ jobs:
       - run: 'yum install --setopt=skip_missing_names_on_install=False -y dpkg-dev fakeroot'
       - run: 'perl -V'
       - run: 'cpanm --notest --installdeps .'
-      - run: 'yath'
+      - run: './configure NAME=debbuild VERSION=version'
+      - run: 'make'
+      - run: 'make check'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: 'yum install --setopt=skip_missing_names_on_install=False -y dpkg-dev fakeroot'
       - run: 'perl -V'
       - run: 'cpanm --notest --installdeps .'
-      - run: './configure NAME=debbuild VERSION=version'
+      - run: './configure'
       - run: 'make'
       - run: 'make check'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Makefile
+debbuild.out

--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,9 @@ MANDIR = @MANDIR@
 DATADIR = @DATADIR@
 DEBCONFIGDIR = @DEBCONFIGDIR@
 
+POD2MAN = @POD2MAN@
+MSGFMT = @MSGFMT@
+
 .DEFAULT_GOAL := build
 .PHONY: build
 build: ;
@@ -30,11 +33,9 @@ install:
 	install -m 644 macros/platform.in $(DESTDIR)$(SYSCONFDIR)/debbuild/macros
 
 	install -d $(DESTDIR)$(MANDIR)/man8
-	pod2man --utf8 --center="DeepNet Dev Tools" --section 8 \
+	$(POD2MAN) --utf8 --center="DeepNet Dev Tools" --section 8 \
 		--release="Release 19.5.0" debbuild \
 		$(DESTDIR)$(MANDIR)/man8/debbuild.8
 
 	install -d $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES
-	msgfmt po/de/debbuild.po -o $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES/debbuild.mo
-
-
+	$(MSGFMT) po/de/debbuild.po -o $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES/debbuild.mo

--- a/Makefile.in
+++ b/Makefile.in
@@ -13,6 +13,11 @@ build: debbuild.out
 debbuild.out: debbuild debbuild.spec
 	# Transfer $VERSION into the live system
 	perl -pe "s/\@VERSION\@/$(VERSION)/" debbuild > debbuild.out
+	chmod +x debbuild.out
+
+.PHONY: check
+check:
+	yath
 
 .PHONY: install
 install:

--- a/Makefile.in
+++ b/Makefile.in
@@ -3,17 +3,10 @@ LIBDIR = @LIBDIR@
 SYSCONFDIR = @SYSCONFDIR@
 MANDIR = @MANDIR@
 DATADIR = @DATADIR@
-NAME = @NAME@
-VERSION = @VERSION@
 
 .DEFAULT_GOAL := build
 .PHONY: build
-build: debbuild.out
-
-debbuild.out: debbuild debbuild.spec
-	# Transfer $VERSION into the live system
-	perl -pe "s/\@VERSION\@/$(VERSION)/" debbuild > debbuild.out
-	chmod +x debbuild.out
+build: ;
 
 .PHONY: check
 check:
@@ -26,18 +19,18 @@ install:
 	install -d $(DESTDIR)$(BINDIR)
 	install debbuild.out $(DESTDIR)$(BINDIR)/debbuild
 
-	install -d $(DESTDIR)$(LIBDIR)/$(NAME)
-	install -m 644 macros/macros.in $(DESTDIR)$(LIBDIR)/$(NAME)/macros
-	install -m 644 config/debrc $(DESTDIR)$(LIBDIR)/$(NAME)
+	install -d $(DESTDIR)$(LIBDIR)/debbuild
+	install -m 644 macros/macros.in $(DESTDIR)$(LIBDIR)/debbuild/macros
+	install -m 644 config/debrc $(DESTDIR)$(LIBDIR)/debbuild
 
-	install -d $(DESTDIR)$(SYSCONFDIR)/$(NAME)
-	install -m 644 macros/macros.sysutils $(DESTDIR)$(SYSCONFDIR)/$(NAME)
-	install -m 644 macros/macros.texlive $(DESTDIR)$(SYSCONFDIR)/$(NAME)
-	install -m 644 macros/platform.in $(DESTDIR)$(SYSCONFDIR)/$(NAME)/macros
+	install -d $(DESTDIR)$(SYSCONFDIR)/debbuild
+	install -m 644 macros/macros.sysutils $(DESTDIR)$(SYSCONFDIR)/debbuild
+	install -m 644 macros/macros.texlive $(DESTDIR)$(SYSCONFDIR)/debbuild
+	install -m 644 macros/platform.in $(DESTDIR)$(SYSCONFDIR)/debbuild/macros
 
 	install -d $(DESTDIR)$(MANDIR)/man8
 	pod2man --utf8 --center="DeepNet Dev Tools" --section 8 \
-		--release="Release $(VERSION)" debbuild \
+		--release="Release 19.5.0" debbuild \
 		$(DESTDIR)$(MANDIR)/man8/debbuild.8
 
 	install -d $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,12 +6,20 @@ DATADIR = @DATADIR@
 NAME = @NAME@
 VERSION = @VERSION@
 
+.DEFAULT_GOAL := build
+.PHONY: build
+build: debbuild.out
+
+debbuild.out: debbuild debbuild.spec
+	# Transfer $VERSION into the live system
+	perl -pe "s/\@VERSION\@/$(VERSION)/" debbuild > debbuild.out
+
 .PHONY: install
 install:
 	rm -rf $(DESTDIR)
 
 	install -d $(DESTDIR)$(BINDIR)
-	install debbuild $(DESTDIR)$(BINDIR)
+	install debbuild.out $(DESTDIR)$(BINDIR)/debbuild
 
 	install -d $(DESTDIR)$(LIBDIR)/$(NAME)
 	install -m 644 macros/macros.in $(DESTDIR)$(LIBDIR)/$(NAME)/macros

--- a/Makefile.in
+++ b/Makefile.in
@@ -3,6 +3,7 @@ LIBDIR = @LIBDIR@
 SYSCONFDIR = @SYSCONFDIR@
 MANDIR = @MANDIR@
 DATADIR = @DATADIR@
+DEBCONFIGDIR = @DEBCONFIGDIR@
 
 .DEFAULT_GOAL := build
 .PHONY: build
@@ -19,9 +20,9 @@ install:
 	install -d $(DESTDIR)$(BINDIR)
 	install debbuild.out $(DESTDIR)$(BINDIR)/debbuild
 
-	install -d $(DESTDIR)$(LIBDIR)/debbuild
-	install -m 644 macros/macros.in $(DESTDIR)$(LIBDIR)/debbuild/macros
-	install -m 644 config/debrc $(DESTDIR)$(LIBDIR)/debbuild
+	install -d $(DESTDIR)$(DEBCONFIGDIR)
+	install -m 644 macros/macros.in $(DESTDIR)$(DEBCONFIGDIR)/macros
+	install -m 644 config/debrc $(DESTDIR)$(DEBCONFIGDIR)
 
 	install -d $(DESTDIR)$(SYSCONFDIR)/debbuild
 	install -m 644 macros/macros.sysutils $(DESTDIR)$(SYSCONFDIR)/debbuild

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,0 +1,33 @@
+BINDIR = @BINDIR@
+LIBDIR = @LIBDIR@
+SYSCONFDIR = @SYSCONFDIR@
+MANDIR = @MANDIR@
+DATADIR = @DATADIR@
+NAME = @NAME@
+VERSION = @VERSION@
+
+.PHONY: install
+install:
+	rm -rf $(DESTDIR)
+
+	install -d $(DESTDIR)$(BINDIR)
+	install debbuild $(DESTDIR)$(BINDIR)
+
+	install -d $(DESTDIR)$(LIBDIR)/$(NAME)
+	install -m 644 macros/macros.in $(DESTDIR)$(LIBDIR)/$(NAME)/macros
+	install -m 644 config/debrc $(DESTDIR)$(LIBDIR)/$(NAME)
+
+	install -d $(DESTDIR)$(SYSCONFDIR)/$(NAME)
+	install -m 644 macros/macros.sysutils $(DESTDIR)$(SYSCONFDIR)/$(NAME)
+	install -m 644 macros/macros.texlive $(DESTDIR)$(SYSCONFDIR)/$(NAME)
+	install -m 644 macros/platform.in $(DESTDIR)$(SYSCONFDIR)/$(NAME)/macros
+
+	install -d $(DESTDIR)$(MANDIR)/man8
+	pod2man --utf8 --center="DeepNet Dev Tools" --section 8 \
+		--release="Release $(VERSION)" debbuild \
+		$(DESTDIR)$(MANDIR)/man8/debbuild.8
+
+	install -d $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES
+	msgfmt po/de/debbuild.po -o $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES/debbuild.mo
+
+

--- a/configure
+++ b/configure
@@ -26,6 +26,8 @@ Getopt::Long::GetOptions(\%options,
   'datadir:s',
   'localedir:s',
   'mandir:s',
+  'pod2man:s',
+  'msgfmt:s',
   '<>' => sub {
     warn "WARN: Skipping unrecognized arg: $_[0]\n";
   },
@@ -42,6 +44,9 @@ $options{'datadir'} //= $options{'datarootdir'};
 $options{'localedir'} //= catdir($options{'datarootdir'}, 'locale');
 $options{'mandir'} //= catdir($options{'datarootdir'}, 'man');
 $options{'debconfigdir'} //= catdir($options{'prefix'}, 'lib', 'debbuild'); # Can't use libdir to define this on 64-bit or Debian systems
+
+$options{'pod2man'} //= check_for_program('pod2man', 'install manpages');
+$options{'msgfmt'} //= check_for_program('msgfmt', 'install locale files');
 
 my $in_filename = 'Makefile.in';
 print "Reading $in_filename...\n";
@@ -61,3 +66,19 @@ print "Writing $out_filename...\n";
 open(my $out, '>', $out_filename);
 print $out $template;
 print "Done.\n";
+
+sub check_for_program {
+  my ($name, $action) = @_;
+
+  print "checking for $name... ";
+
+  my $output = `$name --help`;
+  if ($? == 0) {
+    print "$name\n";
+    return $name;
+  } else {
+    print "no\n";
+    warn "WARN: Unable to find $name, will not $action\n";
+    return ':'; # Will result in a no-op when make executes this
+  }
+}

--- a/configure
+++ b/configure
@@ -53,15 +53,21 @@ $variables{'version'} //= '0.0';
 $variables{'name'} //= $ENV{'NAME'};
 $variables{'name'} //= 'debbuild';
 
-open(my $in, '<', 'Makefile.in');
+my $in_filename = 'Makefile.in';
+print "Reading $in_filename...\n";
+open(my $in, '<', $in_filename);
 my $template = do { local $/ = <$in> }; # Slurp entire file
 
+print "Substituting the following values:\n";
 my %substitutions = (%variables, %options);
 while (my ($name, $value) = each %substitutions) {
-  warn "$name=$value\n";
+  print "  $name=$value\n";
   my $macro = '@'.uc($name).'@';
   $template =~ s/\Q$macro\E/$value/g;
 }
 
-open(my $makefile, '>', 'Makefile');
-print $makefile $template;
+my $out_filename = 'Makefile';
+print "Writing $out_filename...\n";
+open(my $out, '>', $out_filename);
+print $out $template;
+print "Done.\n";

--- a/configure
+++ b/configure
@@ -27,14 +27,7 @@ Getopt::Long::GetOptions(\%options,
   'localedir:s',
   'mandir:s',
   '<>' => sub {
-    my ($arg) = @_;
-    if ($arg =~ m/VERSION=(.*)/) {
-      $variables{'version'}= $1;
-    } elsif ($arg =~ m/NAME=(.*)/) {
-      $variables{'name'}= $1;
-    } else {
-      warn "WARN: Skipping unrecognized arg: $arg\n";
-    }
+    warn "WARN: Skipping unrecognized arg: $_[0]\n";
   },
 );
 
@@ -47,11 +40,6 @@ $options{'datarootdir'} //= catdir($options{'prefix'}, 'share');
 $options{'datadir'} //= $options{'datarootdir'};
 $options{'localedir'} //= catdir($options{'datarootdir'}, 'locale');
 $options{'mandir'} //= catdir($options{'datarootdir'}, 'man');
-
-$variables{'version'} //= $ENV{'VERSION'};
-$variables{'version'} //= '0.0';
-$variables{'name'} //= $ENV{'NAME'};
-$variables{'name'} //= 'debbuild';
 
 my $in_filename = 'Makefile.in';
 print "Reading $in_filename...\n";

--- a/configure
+++ b/configure
@@ -1,0 +1,67 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+use Getopt::Long;
+use File::Spec::Functions qw(catdir); # Handles trailing/repeated slashes
+
+# A compatible subset of an autoconf-like configure script.
+# Used to substitute values from spec macros into the Makefile.
+# Behavior based upon
+#   https://www.gnu.org/prep/standards/html_node/Configuration.html
+#   https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+
+my %options;
+my %variables;
+
+Getopt::Long::Configure('pass_through');
+Getopt::Long::GetOptions(\%options,
+  'prefix:s',
+  'exec-prefix:s',
+  'bindir:s',
+  'sysconfdir:s',
+  'libdir:s',
+  'datarootdir:s',
+  'datadir:s',
+  'localedir:s',
+  'mandir:s',
+  '<>' => sub {
+    my ($arg) = @_;
+    if ($arg =~ m/VERSION=(.*)/) {
+      $variables{'version'}= $1;
+    } elsif ($arg =~ m/NAME=(.*)/) {
+      $variables{'name'}= $1;
+    } else {
+      warn "WARN: Skipping unrecognized arg: $arg\n";
+    }
+  },
+);
+
+$options{'prefix'} //= '';
+$options{'exec_prefix'} //= $options{'prefix'};
+$options{'bindir'} //= catdir($options{'exec_prefix'}, 'bin');
+$options{'sysconfdir'} //= catdir($options{'prefix'}, 'etc');
+$options{'libdir'} //= catdir($options{'exec_prefix'}, 'lib');
+$options{'datarootdir'} //= catdir($options{'prefix'}, 'share');
+$options{'datadir'} //= $options{'datarootdir'};
+$options{'localedir'} //= catdir($options{'datarootdir'}, 'locale');
+$options{'mandir'} //= catdir($options{'datarootdir'}, 'man');
+
+$variables{'version'} //= $ENV{'VERSION'};
+$variables{'version'} //= '0.0';
+$variables{'name'} //= $ENV{'NAME'};
+$variables{'name'} //= 'debbuild';
+
+open(my $in, '<', 'Makefile.in');
+my $template = do { local $/ = <$in> }; # Slurp entire file
+
+my %substitutions = (%variables, %options);
+while (my ($name, $value) = each %substitutions) {
+  warn "$name=$value\n";
+  my $macro = '@'.uc($name).'@';
+  $template =~ s/\Q$macro\E/$value/g;
+}
+
+open(my $makefile, '>', 'Makefile');
+print $makefile $template;

--- a/configure
+++ b/configure
@@ -36,10 +36,12 @@ $options{'exec_prefix'} //= $options{'prefix'};
 $options{'bindir'} //= catdir($options{'exec_prefix'}, 'bin');
 $options{'sysconfdir'} //= catdir($options{'prefix'}, 'etc');
 $options{'libdir'} //= catdir($options{'exec_prefix'}, 'lib');
+$options{'libexecdir'} //= catdir($options{'exec_prefix'}, 'libexec');
 $options{'datarootdir'} //= catdir($options{'prefix'}, 'share');
 $options{'datadir'} //= $options{'datarootdir'};
 $options{'localedir'} //= catdir($options{'datarootdir'}, 'locale');
 $options{'mandir'} //= catdir($options{'datarootdir'}, 'man');
+$options{'debconfigdir'} //= catdir($options{'prefix'}, 'lib', 'debbuild'); # Can't use libdir to define this on 64-bit or Debian systems
 
 my $in_filename = 'Makefile.in';
 print "Reading $in_filename...\n";

--- a/configure
+++ b/configure
@@ -48,6 +48,17 @@ $options{'debconfigdir'} //= catdir($options{'prefix'}, 'lib', 'debbuild'); # Ca
 $options{'pod2man'} //= check_for_program('pod2man', 'install manpages');
 $options{'msgfmt'} //= check_for_program('msgfmt', 'install locale files');
 
+# Die if runtime dependencies are missing
+print 'checking for /etc/os-release... ';
+if (-e '/etc/os-release') {
+  print "yes\n";
+} else {
+  print "no\n";
+  if (check_for_program('/usr/bin/lsb_release', 'be able to run debbulid') eq ':') {
+    die "ERROR: Unable to find os-release or lsb_release. $0 failed.\n";
+  }
+}
+
 my $in_filename = 'Makefile.in';
 print "Reading $in_filename...\n";
 open(my $in, '<', $in_filename);

--- a/debbuild
+++ b/debbuild
@@ -415,7 +415,7 @@ sub parse_cmd {
   }
   ## version()
   sub version {
-    return _('This is debbuild, version ').'@VERSION@'."\n";
+    return _('This is debbuild, version ').'19.5.0'."\n";
   }
   ## dump_macros()
   sub dump_macros {

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -7,6 +7,8 @@
 
 Name: debbuild
 Summary: Build Debian-compatible .deb packages from RPM .spec files
+
+# When bumping the version, change it in the debbuild script and the Makefile.in as well
 Version: 19.5.0
 
 Source: https://github.com/ascherer/debbuild/archive/%{name}-%{version}.tar.gz
@@ -34,7 +36,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 %description
-%{name} attempts to build Debian-friendly semi-native packages from
+debbuild attempts to build Debian-friendly semi-native packages from
 RPM spec files, RPM-friendly tarballs, and RPM source packages
 (.src.rpm files).  It accepts most of the options rpmbuild does, and
 should be able to interpret most spec files usefully.
@@ -48,7 +50,7 @@ rebuild .src.rpm source packages as .deb binary packages.
 %setup -q
 
 %build
-%configure NAME=%{name} VERSION=%{version}
+%configure
 make
 
 %install
@@ -58,10 +60,10 @@ make
 # Fill in the pathnames to be packaged here
 %{_bindir}/*
 %{_mandir}/man8/*
-%{_libdir}/%{name}/debrc
-%{_libdir}/%{name}/macros
-%{_sysconfdir}/%{name}/macros
-%{_sysconfdir}/%{name}/macros.*
+%{_libdir}/debbuild/debrc
+%{_libdir}/debbuild/macros
+%{_sysconfdir}/debbuild/macros
+%{_sysconfdir}/debbuild/macros.*
 %{_datadir}/locale/de/LC_MESSAGES/debbuild.mo
 
 %changelog

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -16,8 +16,6 @@ Group: devel
 %else
 Group: Development/Tools/Building
 %global dist ubuntu18.04
-%define __msgfmt /usr/bin/msgfmt
-%define __pod2man /usr/bin/pod2man
 %endif
 License: GPLv2+
 Packager: Andreas Scherer <https://ascherer.github.io/>
@@ -53,29 +51,10 @@ rebuild .src.rpm source packages as .deb binary packages.
 # Transfer $VERSION into the live system
 %{__perl} -pe "s/\@VERSION\@/%{version}/" -i debbuild
 
+%configure NAME=%{name} VERSION=%{version}
+
 %install
-# Steps to install to a temporary location for packaging
-%{__rm} -rf %{buildroot}
-
-%{__install} -d %{buildroot}%{_bindir}
-%{__install} debbuild %{buildroot}%{_bindir}
-
-%{__install} -d %{buildroot}%{_libdir}/%{name}
-%{__install} -m 644 macros/macros.in %{buildroot}%{_libdir}/%{name}/macros
-%{__install} -m 644 config/debrc %{buildroot}%{_libdir}/%{name}
-
-%{__install} -d %{buildroot}%{_sysconfdir}/%{name}
-%{__install} -m 644 macros/macros.sysutils %{buildroot}%{_sysconfdir}/%{name}
-%{__install} -m 644 macros/macros.texlive %{buildroot}%{_sysconfdir}/%{name}
-%{__install} -m 644 macros/platform.in %{buildroot}%{_sysconfdir}/%{name}/macros
-
-%{__install} -d %{buildroot}%{_mandir}/man8
-%{__pod2man} --utf8 --center="DeepNet Dev Tools" --section 8 \
-	--release="Release %{version}" debbuild \
-	%{buildroot}%{_mandir}/man8/debbuild.8
-
-%{__install} -d %{buildroot}%{_datadir}/locale/de/LC_MESSAGES
-%{__msgfmt} po/de/debbuild.po -o %{buildroot}%{_datadir}/locale/de/LC_MESSAGES/debbuild.mo
+%make_install
 
 %files
 # Fill in the pathnames to be packaged here

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -48,10 +48,8 @@ rebuild .src.rpm source packages as .deb binary packages.
 %setup -q
 
 %build
-# Transfer $VERSION into the live system
-%{__perl} -pe "s/\@VERSION\@/%{version}/" -i debbuild
-
 %configure NAME=%{name} VERSION=%{version}
+make
 
 %install
 %make_install

--- a/t/001_version.t
+++ b/t/001_version.t
@@ -2,5 +2,5 @@ use Test2::V0;
 
 plan 1;
 
-chomp(my $version_string = `./debbuild.out --version`);
+chomp(my $version_string = `./debbuild --version`);
 like($version_string, qr/This is debbuild, version/, 'Verify that debbuild --version runs');

--- a/t/001_version.t
+++ b/t/001_version.t
@@ -2,5 +2,5 @@ use Test2::V0;
 
 plan 1;
 
-chomp(my $version_string = `./debbuild --version`);
-is($version_string, 'This is debbuild, version @VERSION@', 'Verify that debbuild --version runs');
+chomp(my $version_string = `./debbuild.out --version`);
+like($version_string, qr/This is debbuild, version/, 'Verify that debbuild --version runs');


### PR DESCRIPTION
Factor parts of the specfile out into a separate Makefile.in. There is deliberately no Makefile.ac because we're not actually using autotools.

Provide a "configure" script that implements a minimal compatabile
subset of autotools configure functionality, namely, the part where
it composes paths and then substitutes values into a Makefile.in to
create a Makefile.

The Makefile currently provides targets for substituting the version into the debbuild script, running tests, and installing.

This should not change any runtime functionality, but it does alter the development workflow.

Motivation: breaking out build and install steps into a Makefile makes it easier to reuse them in tests and during development. Tests in particular will [need to change some file paths](https://github.com/debbuild/debbuild/issues/114) and until that can happen at runtime, it may make sense to do it at build time.