### PR TITLE
Install macros into /usr/lib/debbuild/macros.d instead of /etc/debbuild

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -27,10 +27,12 @@ install:
 	install -m 644 macros/macros.in $(DESTDIR)$(DEBCONFIGDIR)/macros
 	install -m 644 config/debrc $(DESTDIR)$(DEBCONFIGDIR)
 
+	install -d $(DESTDIR)$(DEBCONFIGDIR)/macros.d
+	install -m 644 macros/macros.sysutils $(DESTDIR)$(DEBCONFIGDIR)/macros.d
+	install -m 644 macros/macros.texlive $(DESTDIR)$(DEBCONFIGDIR)/macros.d
+	install -m 644 macros/platform.in $(DESTDIR)$(DEBCONFIGDIR)/macros.d/macros.00platform
+
 	install -d $(DESTDIR)$(SYSCONFDIR)/debbuild
-	install -m 644 macros/macros.sysutils $(DESTDIR)$(SYSCONFDIR)/debbuild
-	install -m 644 macros/macros.texlive $(DESTDIR)$(SYSCONFDIR)/debbuild
-	install -m 644 macros/platform.in $(DESTDIR)$(SYSCONFDIR)/debbuild/macros
 
 	install -d $(DESTDIR)$(MANDIR)/man8
 	$(POD2MAN) --utf8 --center="DeepNet Dev Tools" --section 8 \

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -60,10 +60,10 @@ make
 # Fill in the pathnames to be packaged here
 %{_bindir}/*
 %{_mandir}/man8/*
-%{_libdir}/debbuild/debrc
-%{_libdir}/debbuild/macros
-%{_sysconfdir}/debbuild/macros
-%{_sysconfdir}/debbuild/macros.*
+%{_prefix}/lib/debbuild/debrc
+%{_prefix}/lib/debbuild/macros
+%{_prefix}/lib/debbuild/macros.d/
+%{_sysconfdir}/debbuild/
 %{_datadir}/locale/de/LC_MESSAGES/debbuild.mo
 
 %changelog


### PR DESCRIPTION
Macros provided by packages should be installed into the vendor
directories instead of the local configuration directory.