### PR TITLE
Add ability to configure at build-time without sed 

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -8,9 +8,16 @@ DEBCONFIGDIR = @DEBCONFIGDIR@
 POD2MAN = @POD2MAN@
 MSGFMT = @MSGFMT@
 
+VERSION = @VERSION@
+
 .DEFAULT_GOAL := build
 .PHONY: build
-build: ;
+build: debbuild.out
+
+debbuild.out: debbuild debbuild.spec
+	cp debbuild debbuild.out
+	echo "version:$(VERSION)" >> debbuild.out
+	chmod +x debbuild.out
 
 .PHONY: check
 check:
@@ -36,7 +43,7 @@ install:
 
 	install -d $(DESTDIR)$(MANDIR)/man8
 	$(POD2MAN) --utf8 --center="DeepNet Dev Tools" --section 8 \
-		--release="Release 19.5.0" debbuild \
+		--release="Release $(VERSION)" debbuild \
 		$(DESTDIR)$(MANDIR)/man8/debbuild.8
 
 	install -d $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES

--- a/Makefile.in
+++ b/Makefile.in
@@ -16,7 +16,9 @@ build: debbuild.out
 
 debbuild.out: debbuild debbuild.spec
 	cp debbuild debbuild.out
-	echo "version:$(VERSION)" >> debbuild.out
+	echo "\
+version:$(VERSION)\n\
+debconfigdir:$(DEBCONFIGDIR)\n" >> debbuild.out
 	chmod +x debbuild.out
 
 .PHONY: check

--- a/Makefile.in
+++ b/Makefile.in
@@ -18,7 +18,8 @@ debbuild.out: debbuild debbuild.spec
 	cp debbuild debbuild.out
 	echo "\
 version:$(VERSION)\n\
-debconfigdir:$(DEBCONFIGDIR)\n" >> debbuild.out
+debconfigdir:$(DEBCONFIGDIR)\n\
+sysconfdir:$(SYSCONFDIR)\n" >> debbuild.out
 	chmod +x debbuild.out
 
 .PHONY: check

--- a/configure
+++ b/configure
@@ -29,7 +29,12 @@ Getopt::Long::GetOptions(\%options,
   'pod2man:s',
   'msgfmt:s',
   '<>' => sub {
-    warn "WARN: Skipping unrecognized arg: $_[0]\n";
+    my ($arg) = shift;
+    if ($arg =~ m/VERSION=(.*)/) {
+      $variables{'version'} = $1;
+    } else {
+      warn "WARN: Skipping unrecognized arg: $arg\n";
+    }
   },
 );
 
@@ -44,6 +49,9 @@ $options{'datadir'} //= $options{'datarootdir'};
 $options{'localedir'} //= catdir($options{'datarootdir'}, 'locale');
 $options{'mandir'} //= catdir($options{'datarootdir'}, 'man');
 $options{'debconfigdir'} //= catdir($options{'prefix'}, 'lib', 'debbuild'); # Can't use libdir to define this on 64-bit or Debian systems
+
+$variables{'version'} //= $ENV{'VERSION'};
+$variables{'version'} //= '0.0';
 
 $options{'pod2man'} //= check_for_program('pod2man', 'install manpages');
 $options{'msgfmt'} //= check_for_program('msgfmt', 'install locale files');

--- a/configure
+++ b/configure
@@ -26,6 +26,7 @@ Getopt::Long::GetOptions(\%options,
   'datadir:s',
   'localedir:s',
   'mandir:s',
+  'debconfigdir:s',
   'pod2man:s',
   'msgfmt:s',
   '<>' => sub {

--- a/debbuild
+++ b/debbuild
@@ -221,6 +221,7 @@ sub load_static_config {
   my %static_config = read_debrc_from_handle(*DATA);
 
   $static_config{version} //= '0.0';
+  $static_config{debconfigdir} //= '/usr/lib/debbuild';
 
   return %static_config;
 }
@@ -233,8 +234,8 @@ sub load_static_config {
 sub load_config {
   # Load user configuration, permitting local override
   my $homedir = $ENV{HOME} // $ENV{LOGDIR} // (getpwuid($<))[7];
-  foreach my $macros ( ('/usr/lib/debbuild/macros',
-                        </usr/lib/debbuild/macros.d/macros.*>,
+  foreach my $macros ( ("$static_config{debconfigdir}/macros",
+                        glob("$static_config{debconfigdir}/macros.d/macros.*"),
                         '/etc/debbuild/macros',
                         </etc/debbuild/macros.*>,
                         "$homedir/.debmacros") ) {
@@ -261,7 +262,7 @@ sub load_config {
 sub config_debrc {
   # Load default configuration, permitting local override
   my $homedir = $ENV{HOME} // $ENV{LOGDIR} // (getpwuid($<))[7];
-  foreach my $macros ( ('/usr/lib/debbuild/debrc',
+  foreach my $macros ( ("$static_config{debconfigdir}/debrc",
                         '/etc/debrc',
                         "$homedir/.debrc") ) {
     open(my $macros_handle, $macros) or next; # should we warn about missing macro files?

--- a/debbuild
+++ b/debbuild
@@ -222,6 +222,7 @@ sub load_static_config {
 
   $static_config{version} //= '0.0';
   $static_config{debconfigdir} //= '/usr/lib/debbuild';
+  $static_config{sysconfdir} //= '/etc';
 
   return %static_config;
 }
@@ -236,8 +237,8 @@ sub load_config {
   my $homedir = $ENV{HOME} // $ENV{LOGDIR} // (getpwuid($<))[7];
   foreach my $macros ( ("$static_config{debconfigdir}/macros",
                         glob("$static_config{debconfigdir}/macros.d/macros.*"),
-                        '/etc/debbuild/macros',
-                        </etc/debbuild/macros.*>,
+                        "$static_config{sysconfdir}/debbuild/macros",
+                        glob("$static_config{sysconfdir}/debbuild/macros.*"),
                         "$homedir/.debmacros") ) {
     open MACROS,$macros or next; # should we warn about missing macro files?
     while (<MACROS>) {
@@ -263,7 +264,7 @@ sub config_debrc {
   # Load default configuration, permitting local override
   my $homedir = $ENV{HOME} // $ENV{LOGDIR} // (getpwuid($<))[7];
   foreach my $macros ( ("$static_config{debconfigdir}/debrc",
-                        '/etc/debrc',
+                        "$static_config{sysconfdir}/debrc",
                         "$homedir/.debrc") ) {
     open(my $macros_handle, $macros) or next; # should we warn about missing macro files?
     my %entries = read_debrc_from_handle($macros_handle);

--- a/debbuild
+++ b/debbuild
@@ -56,6 +56,8 @@ my %defattr = (filemode => '-',
 		group => '-',
 		dirmode => '-');
 
+my %static_config = load_static_config();
+
 # Scriptlets
 my %script = (prep => '',
 		build => '',
@@ -206,6 +208,22 @@ FINAL: print expandmacros($finalmessages) if defined $specglobals{verbose};
 exit 0;
 
 #### end main ####
+
+## load_static_config()
+# Load build-time configuration for debbuild itself.
+# The Makefile stores this configuration as a debrc-format
+# file in the __DATA__ section of this file to avoid relying
+# on external file paths.
+#
+# Values are given defaults so that debbuild still runs without
+# having to be passed through the Makefile.
+sub load_static_config {
+  my %static_config = read_debrc_from_handle(*DATA);
+
+  $static_config{version} //= '0.0';
+
+  return %static_config;
+}
 
 
 ## load_config()
@@ -439,7 +457,7 @@ sub parse_cmd {
   }
   ## version()
   sub version {
-    return _('This is debbuild, version ').'19.5.0'."\n";
+    return _('This is debbuild, version ').$static_config{version}."\n";
   }
   ## dump_macros()
   sub dump_macros {
@@ -2056,3 +2074,5 @@ Documentation, such as it is, will likely remain perpetually out of date (in whi
 rpm(8), rpmbuild(8), and pretty much any document describing how to write a .spec file.
 
 =cut
+__DATA__
+# Build-time configuration added by the Makefile:

--- a/debbuild
+++ b/debbuild
@@ -246,15 +246,39 @@ sub config_debrc {
   foreach my $macros ( ('/usr/lib/debbuild/debrc',
                         '/etc/debrc',
                         "$homedir/.debrc") ) {
-    open MACROS,$macros or next; # should we warn about missing macro files?
-    while (<MACROS>) {
-      next unless my ($flag,$value) = /^optflags:\s+(\w+)\s+(.+)$/;
+    open(my $macros_handle, $macros) or next; # should we warn about missing macro files?
+    my %entries = read_debrc_from_handle($macros_handle);
+
+    if (exists $entries{optflags}) {
+      next unless $entries{optflags} =~ /^\s+(\w+)\s+(.+)$/;
+      my ($flag,$value) = ($1,$2);
       $optflags{$flag} = $value;
     }
-    close MACROS;
+    close $macros_handle;
   }
 } # end config_debrc()
 
+## read_debrc_from_handle()
+# Take a filehandle of a debrc-format file and parse entries out of it
+# Returns a hash of entries, with keys lowercased to normalize them
+# Ignores lines it doesn't understand
+sub read_debrc_from_handle {
+  my ($debrc_fh) = shift;
+
+  my %entries;
+
+  while(my $line = <$debrc_fh>) {
+    chomp($line);
+    next unless $line =~ /^(\w+):(.+)$/;
+    my $name = lc($1); # Names are case-insensitive; normalize by lowercasing
+    my $value = $2;
+
+    $entries{$name} = $value
+  }
+
+  return %entries;
+}
+# end read_debrc_from_handle()
 
 ## lsb_detection()
 # Setup for OS detection

--- a/debbuild
+++ b/debbuild
@@ -1899,7 +1899,7 @@ sub handle_macro_options {
 } # end handle_macro_options()
 
 
-__END__
+=pod
 
 =encoding utf8
 

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -8,7 +8,6 @@
 Name: debbuild
 Summary: Build Debian-compatible .deb packages from RPM .spec files
 
-# When bumping the version, change it in the debbuild script and the Makefile.in as well
 Version: 19.5.0
 
 Source: https://github.com/ascherer/debbuild/archive/%{name}-%{version}.tar.gz
@@ -50,7 +49,7 @@ rebuild .src.rpm source packages as .deb binary packages.
 %setup -q
 
 %build
-%configure
+%configure VERSION=%{version}
 make
 
 %install

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -34,6 +34,8 @@ Suggests: rpm
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
+%define debconfigdir %{_prefix}/lib/debbuild
+
 %description
 debbuild attempts to build Debian-friendly semi-native packages from
 RPM spec files, RPM-friendly tarballs, and RPM source packages
@@ -49,7 +51,7 @@ rebuild .src.rpm source packages as .deb binary packages.
 %setup -q
 
 %build
-%configure VERSION=%{version}
+%configure --debconfigdir=%{debconfigdir} VERSION=%{version}
 make
 
 %install
@@ -59,9 +61,9 @@ make
 # Fill in the pathnames to be packaged here
 %{_bindir}/*
 %{_mandir}/man8/*
-%{_prefix}/lib/debbuild/debrc
-%{_prefix}/lib/debbuild/macros
-%{_prefix}/lib/debbuild/macros.d/
+%{debconfigdir}/debrc
+%{debconfigdir}/macros
+%{debconfigdir}/macros.d/
 %{_sysconfdir}/debbuild/
 %{_datadir}/locale/de/LC_MESSAGES/debbuild.mo
 

--- a/t/001_version.t
+++ b/t/001_version.t
@@ -2,5 +2,5 @@ use Test2::V0;
 
 plan 1;
 
-chomp(my $version_string = `./debbuild --version`);
+chomp(my $version_string = `./debbuild.out --version`);
 like($version_string, qr/This is debbuild, version/, 'Verify that debbuild --version runs');


### PR DESCRIPTION
Add new mechanism for providing build-time configuration to debbuild.
The old mechanism of sed-ing into the source code was brittle and hard
to get right.

Instead, use the __DATA__ section at the end of the debbuild file to
append an rpmrc-format file with build-time configuration. debbuild
parses this at startup and uses it if it exists. If not, it falls back
to default values to ensure that debbuild will still run directly in its
source form.

The configuration added at build-time is:
- version
- debconfigdir
- sysconfdir

which will allow unit tests to load macros and config from non-installed locations.

debrc parsing has been centralized to a helper function used for this purpose.