### PR TITLE
Revert "Enable backslash escape in shell scripts."

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1897,7 +1897,7 @@ sub expandmacros {
 
   # unescape multi-line macros
   s/\\"/"/g;
-  s/\\\\$/\\/g;
+  s/\\\\/\\/g;
   s/(\S)\\+\n/$1\n/g;
   # revert changes of dir macro because of spcial use in %files
   s/%\{dir\}/%dir/g;


### PR DESCRIPTION
This change broke some macros that embedded escaped characters.

This reverts commit c2aa351938af86a0c52649185cf44d9cb6e997d9.