### PR TITLE
Load debrc and macros during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Makefile
 debbuild.out
+makecheck/

--- a/Makefile.in
+++ b/Makefile.in
@@ -10,6 +10,11 @@ MSGFMT = @MSGFMT@
 
 VERSION = @VERSION@
 
+# Prefix separate from DESTDIR used to set static configuration paths
+# Only set during "make check".
+# Used because debbuild shouldn't know about DESTDIR at runtime.
+SCRIPTPATHPREFIX=
+
 .DEFAULT_GOAL := build
 .PHONY: build
 build: debbuild.out
@@ -18,12 +23,16 @@ debbuild.out: debbuild debbuild.spec
 	cp debbuild debbuild.out
 	echo "\
 version:$(VERSION)\n\
-debconfigdir:$(DEBCONFIGDIR)\n\
-sysconfdir:$(SYSCONFDIR)\n" >> debbuild.out
+debconfigdir:$(SCRIPTPATHPREFIX)$(DEBCONFIGDIR)\n\
+sysconfdir:$(SCRIPTPATHPREFIX)$(SYSCONFDIR)\n" >> debbuild.out
 	chmod +x debbuild.out
 
 .PHONY: check
-check:
+check: DESTDIR = $(shell pwd)/makecheck
+check: SCRIPTPATHPREFIX = $(shell pwd)/makecheck
+check: DEBCONFIGDIR = /lib/debbuild
+check: SYSCONFDIR = /etc
+check: debbuild.out install
 	yath
 
 .PHONY: install

--- a/t/001_version.t
+++ b/t/001_version.t
@@ -2,5 +2,8 @@ use Test2::V0;
 
 plan 1;
 
-chomp(my $version_string = `./debbuild.out --version`);
+my $script_path = './makecheck/bin/debbuild';
+-x $script_path  or bail_out("Unable to find $script_path . Run tests under 'make check' to generate it");
+
+chomp(my $version_string = `$script_path --version`);
 like($version_string, qr/This is debbuild, version/, 'Verify that debbuild --version runs');


### PR DESCRIPTION
Allow test runs that use a debbuild built to reference files from this
repository rather than their installed locations. This will enable
complete end-to-end automated tests that use macros and debrc without
installing them.

During "make check", set a DESTDIR of $pwd/makecheck and perform a "make
install" into that directory. Build a "debbuild.out" with paths that
point to this directory. Then, invoke the makecheck/bin/debbuild in
tests.

This has a substantial caveat that `debbuild.out` clashes between "make
build" and "make check", that is, that "make" isn't smart enough to
rebuild the file if one target is invoked after the other. Suggestions
on how to deal with this are welcome.

Introduce a new SCRIPTPATHPREFIX make variable that's normally an empty
string, but set to the DESTDIR during "make check". We never want
DESTDIR to be part of paths baked into debbuild because DESTDIR is
usually a temporary directory made during package build that doesn't
reflect the final installed location. However, we're using DESTDIR in
this case to redirectt files to the "makecheck" directory, so we need a
mechanism to make debbuild look there.