### PR TITLE
Support sed 'in-place' replacement on BSD.

### DIFF
--- a/macros/macros.in
+++ b/macros/macros.in
@@ -54,6 +54,7 @@
 %__rm			/bin/rm
 %__rpm			/usr/bin/rpm
 %__sed			/bin/sed
+%__sed_i		/bin/sed -i
 %__tar			/bin/tar
 %__test			/usr/bin/test
 %__unzip		/usr/bin/unzip


### PR DESCRIPTION
BSD's sed requires an `extension` for the `-i` option, even an 'empty' (`""`) extension to suppress creation of a backup for 'in-place' editing. With `'%{__sed_i}` it should be easier to write portable specfiles for both GNU/Linux and BSD based systems. The latter should simply redefine
```
%__sed_i /bin/sed -i ""
```
in a local macro file or
```
%global __sed_i /bin/sed -i ""
```
in a specfile.