### PR TITLE
Fix issue #131.

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1897,7 +1897,7 @@ sub expandmacros {
 
   # unescape multi-line macros
   s/\\"/"/g;
-  s/\\\\/\\/g;
+  s/\\\\(\w)/\\$1/g;
   s/(\S)\\+\n/$1\n/g;
   # revert changes of dir macro because of spcial use in %files
   s/%\{dir\}/%dir/g;


### PR DESCRIPTION
Reduce escaped backslash only for use as escape backslash, e.g. `\\n` becomes `\n`, but `\\\\\[` stays intact.