### PR TITLE
Fix issue #135.

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -541,9 +541,9 @@ LINE: while (<$fh>) {
     # Extracted from the Maximum RPM online doc via:
     # grep -h %[a-z] *|perl -e 'while (<>) { /%([a-z0-9]+)\b/; print "$1|\n"; }'|sort -u
     # First a set of %-tags that are required to be used flush-left:
-    if ((/^%([a-z_]\w*)/ and not grep { $1 eq $_ } qw(build changelog check
+    if ((/^%([a-z_]\w*)/ and not (grep { $1 eq $_ } qw(build changelog check
         clean config copyrightdata description files ghost install package
-        patch post postun pre prep preun setup verify))
+        post postun pre prep preun setup verify) or /patch\d*/))
         and # then a set of %-tags that are permitted in more liberal layouts:
         (/^\s*%([a-z_]\w*)/ and not grep { $1 eq $_ } qw(attr autopatch
         autosetup bcond_with bcond_without configure defattr define dir


### PR DESCRIPTION
Quck-and-dirty test on MacOS and [cwebbin](https://github.com/ascherer/cwebbin.git) with the obvious non-`auto` changes in `cwebbin.spec`
```
%setup -c -a1 -a2
%patch2 -p1
%patch -P4 -p1
```
and the local invocation `./debbuild -vv -bp SPECS/cwebbin.spec` works as expected.

Positive result confirmed on the main Linux system.