### PR TITLE
Remove unnecessary escaping for Requires(pre)/Requires(preun)

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -752,7 +752,6 @@ ENDIF: if (/^\s*%endif/) {
           Recommends|Suggests|Enhances|Obsoletes|Breaks|Replaces|
           PreReq|Requires(?:\(pre(?:un)?\))?|Pre-Depends):\s+(.+)$/ix) {
         $dname =~ tr/[A-Z]/[a-z]/;
-        $dname =~ s/([()])/\\$1/g;
         $dvalue =~ s/^noarch/all/i if $dname =~ s/^BuildArch(?:itecture)?/arch/i;
         if (grep { $dname eq $_ } qw(recommends suggests enhances breaks
             replaces requires conflicts provides pre-depends)) {


### PR DESCRIPTION
With 51dccbd392f7d82ea1d30f53d86e811ccfb11994, debbuild switched
from using regular expressions to do fuzzy matching on stanzas
declared in a subpackage to using exact literal matches.

However, the extra escaping of parens that was supposed to be removed
as part of changing to using exact literal matching was left in,
causing the keys read in for `Requires(pre)` and `Requires(preun)`
to be escaped and thus fail to match with the right value in the
quote word group.

This extra escaping was necessary with the fuzzy matching logic
because otherwise the parens would be considered as a capturing
group in a regular expression. Since we do not use regular
expressions to identify the stanzas anymore, this became
unnecessary.

Dropping the statement that does the extra escaping fixes the
handling for these dependency stanzas.

Fixes #140