### PR TITLE
Process Supplements in subpackages

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -749,13 +749,18 @@ ENDIF: if (/^\s*%endif/) {
 # an rpmbuild-compatible .spec file
       if (my ($dname,$dvalue) = /^(Summary|Group|Version|Conflicts|Provides|
           BuildArch(?:itecture)?|BuildRequires|BuildConflicts|
-          Recommends|Suggests|Enhances|Obsoletes|Breaks|Replaces|
+          Recommends|Supplements|Suggests|Enhances|Obsoletes|Breaks|Replaces|
           PreReq|Requires(?:\(pre(?:un)?\))?|Pre-Depends):\s+(.+)$/ix) {
         $dname =~ tr/[A-Z]/[a-z]/;
         $dvalue =~ s/^noarch/all/i if $dname =~ s/^BuildArch(?:itecture)?/arch/i;
         if (grep { $dname eq $_ } qw(recommends suggests enhances breaks
             replaces requires conflicts provides pre-depends)) {
           push @{$pkgdata{$subname}{$dname}}, splitreqs($dvalue);
+        } elsif (grep { $dname eq $_ } qw(supplements)) {
+          push @{$pkgdata{$subname}{enhances}}, splitreqs($dvalue);
+          warn _('Warning:  \'').
+               _("Supplements:' is not natively supported by .deb packages.\n").
+               _("Downgrading relationship to Enhances:.\n");
         } elsif (grep { $dname eq $_ } qw{prereq requires(pre) requires(preun)}) {
           push @{$pkgdata{$subname}{'pre-depends'}}, splitreqs($dvalue);
         } elsif (grep { $dname eq $_ } qw(obsoletes)) {


### PR DESCRIPTION
Currently, we completely skip over Supplements clauses in subpackages.
This means that weak dependencies declared in this way will not be in
the resulting package. Because Debian doesn't have this type of
relationship, map it to the weaker relationship Enhances and print a
warning for the user.

Fixes #143 