### PR TITLE
Assimilate warning texts.

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -768,7 +768,7 @@ ENDIF: if (/^\s*%endif/) {
           push @{$pkgdata{$subname}{requires}}, splitreqs($dvalue);
           warn _('Warning:  \'').$dname_orig.
                _(":' is not natively supported by .deb packages.\n").
-               _("Upgrading relationship to Requires.\n");
+               _("Upgrading relationship to Requires:.\n");
         } elsif (grep { $dname eq $_ } qw(obsoletes)) {
           push @{$pkgdata{$subname}{replaces}}, splitreqs($dvalue);
         } elsif (grep { $dname eq $_ } qw(buildrequires)) {


### PR DESCRIPTION
I'm in the process of upgrading `po/debbuild.pot` and found two _almost_ identical strings. Colon added to make all these warnings similar.