### PR TITLE
Straighten English vs. French spacing.

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -460,8 +460,8 @@ sub parse_cmd {
     if (defined $value) {
       store_value($opt_name,$macro,$value);
     } else {
-      warn _('WARNING: missing value for macro ').
-        "$macro in --$opt_name"._("! Ignoring.\n");
+      warn _('WARNING:  Missing value for macro ').
+        "$macro in --$opt_name"._("!  Ignoring.\n");
     }
   }
   ## help_handler()
@@ -509,7 +509,7 @@ sub parse_spec {
 
   die _("No .spec file specified!  Exiting.\n") unless $specfile;
   open $fh, $specfile or die _('specfile (').$specfile.
-    _(') barfed: ')."$!\n";
+    _(') barfed:  ')."$!\n";
 
   my @ifexpr = (); # Nested %if..%else..%endif conditionals
 
@@ -609,11 +609,11 @@ LINE: while (<$fh>) {
           $iflevel--;
         }
       }
-      die _("Unmatched %if at end of file. Missing %else/%endif.\n");
+      die _("Unmatched %if at end of file.  Missing %else/%endif.\n");
     }
 ELSE: if (/^\s*%else/) {
       die _('Unmatched %else in line ').$..
-          _(". Missing %if.\n") unless @ifexpr;
+          _(".  Missing %if.\n") unless @ifexpr;
       next LINE unless $ifexpr[-1];
       my $iflevel = @ifexpr;
       while (<$fh>) { # Skip %else-block, inluding nested %if..%else..%endif
@@ -626,11 +626,11 @@ ELSE: if (/^\s*%else/) {
           $iflevel--;
         }
       }
-      die _("Unmatched %else at end of file. Missing %endif.\n");
+      die _("Unmatched %else at end of file.  Missing %endif.\n");
     }
 ENDIF: if (/^\s*%endif/) {
       die _('Unmatched %endif in line ').$..
-          _(". Missing %if/%else.\n") unless @ifexpr;
+          _(".  Missing %if/%else.\n") unless @ifexpr;
       pop @ifexpr;
     } # %if..%else..%endif
 
@@ -904,7 +904,7 @@ sub process_autosetup {
   my $noautopatch = s/\s+-N//; # Eat '-N', which is unknown to %setup
   $specglobals{__scm} = $1 if s/\s+\-S\s+(\w+)//; # dito '-S'
   my $scm = $specglobals{__scm};
-  die _('%autosetup: option \'-S ').$scm.
+  die _('%autosetup:  option \'-S ').$scm.
       _('\' currently not supported at line ').$..".\n"
     unless $specglobals{"__scm_setup_$scm"};
   # Generic %setup invocation
@@ -1296,7 +1296,7 @@ sub install {
       unlink $manpage;
       $manpage =~ s/\.(?:Z|gz|bz2)//;
       symlink "$linkdest.gz", "$manpage.gz" or
-        warn _('Warning: symlinking manpage failed: ')."$!\n";
+        warn _('Warning:  symlinking manpage failed:  ')."$!\n";
     }
   }
 
@@ -1647,7 +1647,7 @@ sub checkbuildreq {
       my ($reqstat,undef,undef,$reqver) = split ' ', $pkgdep;
       if ($reqstat =~ /^unknown/) {
 	# this seems to be a virtual package.
-	warn _(' * Warning: ').$pkg.
+	warn _(' * Warning:  ').$pkg.
           _(" is probably installed but seems to be a virtual package.\n");
       } elsif ($reqstat =~ /^install/) {
 	my ($resp) = qx ( $specglobals{__dpkg} --compare-versions $reqver '$rel' $ver && $specglobals{__echo} "ok" );
@@ -1819,7 +1819,7 @@ sub expandmacros {
   # Store %globals (from '%bcond_with[out]()' in 'macros[.in]')
   s/%(define|global)\s+(\S+)\s+(.+)/store_value($1,$2,$3)/eg;
   die _('Missing value for \'%')."$1 $2".
-      _('\'. Aborting!') if m/%(define|global)\s+(.+)/;
+      _('\'.  Aborting!') if m/%(define|global)\s+(.+)/;
   # Permit unsetting/deleting of stored values
   { no warnings; s/%(undefine)\s+(\S+)/store_value($1,$2)/eg; }
   # Print the active macro table

--- a/po/de/debbuild.po
+++ b/po/de/debbuild.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: DEBBUILD I18N 1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-30 09:40+0100\n"
-"PO-Revision-Date: 2020-01-30 10:12+0100\n"
+"POT-Creation-Date: 2020-02-06 09:46+0100\n"
+"PO-Revision-Date: 2020-02-06 09:52+0100\n"
 "Last-Translator: Andreas Scherer <andreas_github@freenet.de>\n"
 "Language-Team: German\n"
 "Language: de\n"
@@ -38,7 +38,7 @@ msgid " * Required build-dependency "
 msgstr " * Notwendige Bau-Abhängigkeit "
 
 #: debbuild:1650
-msgid " * Warning: "
+msgid " * Warning:  "
 msgstr " * Warnung: "
 
 #: debbuild:1261
@@ -79,11 +79,11 @@ msgid " with --rebuild\n"
 msgstr " mit --rebuild\n"
 
 #: debbuild:464
-msgid "! Ignoring.\n"
+msgid "!  Ignoring.\n"
 msgstr "! Ignoriert.\n"
 
 #: debbuild:907
-msgid "%autosetup: option '-S "
+msgid "%autosetup:  option '-S "
 msgstr "%autosetup: Option '-S "
 
 #: debbuild:558
@@ -104,11 +104,11 @@ msgid "', continuing\n"
 msgstr "', setze fort\n"
 
 #: debbuild:1822
-msgid "'. Aborting!"
+msgid "'.  Aborting!"
 msgstr "'. Abbruch!"
 
 #: debbuild:512
-msgid ") barfed: "
+msgid ") barfed:  "
 msgstr ") schimpfte: "
 
 #: debbuild:1657
@@ -121,12 +121,12 @@ msgstr "**WARNUNG** "
 
 #: debbuild:616
 #, perl-format
-msgid ". Missing %if.\n"
+msgid ".  Missing %if.\n"
 msgstr ". Fehlendes %if.\n"
 
 #: debbuild:633
 #, perl-format
-msgid ". Missing %if/%else.\n"
+msgid ".  Missing %if/%else.\n"
 msgstr ". Fehlendes %if/%else.\n"
 
 #: debbuild:179
@@ -245,7 +245,7 @@ msgstr "Unbekannter Marker '%"
 
 #: debbuild:629
 #, perl-format
-msgid "Unmatched %else at end of file. Missing %endif.\n"
+msgid "Unmatched %else at end of file.  Missing %endif.\n"
 msgstr "Nicht geschlossenes %else am Dateiende. Fehlendes %endif.\n"
 
 #: debbuild:615
@@ -260,12 +260,12 @@ msgstr "Einsames %endif in Zeile "
 
 #: debbuild:612
 #, perl-format
-msgid "Unmatched %if at end of file. Missing %else/%endif.\n"
+msgid "Unmatched %if at end of file.  Missing %else/%endif.\n"
 msgstr "Nicht geschlossenes %if am Dateiende. Fehlendes %else/%endif.\n"
 
 #: debbuild:886
 #, perl-format
-msgid "Unmatched %if at end of file. Missing %endif.\n"
+msgid "Unmatched %if at end of file.  Missing %endif.\n"
 msgstr "Nicht geschlossenes %if am Dateiende. Fehlendes %endif.\n"
 
 #: debbuild:771 debbuild:856
@@ -273,7 +273,7 @@ msgid "Upgrading relationship to Requires:.\n"
 msgstr "Setze Abhängigkeit auf Requires:.\n"
 
 #: debbuild:463
-msgid "WARNING: missing value for macro "
+msgid "WARNING:  Missing value for macro "
 msgstr "WARNUNG: Fehlender Wert für Makro "
 
 #: debbuild:762 debbuild:769 debbuild:854 debbuild:861 debbuild:869
@@ -285,7 +285,7 @@ msgid "Warning:  Debian-specific '"
 msgstr "Warnung: Debian-eigenes '"
 
 #: debbuild:1299
-msgid "Warning: symlinking manpage failed: "
+msgid "Warning:  symlinking manpage failed:  "
 msgstr "Warnung: Kann Symlink für Manpage nicht setzen: "
 
 #: debbuild:1505

--- a/po/debbuild.pot
+++ b/po/debbuild.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: DEBBUILD I18N 1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-30 09:40+0100\n"
+"POT-Creation-Date: 2020-02-06 09:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,7 +38,7 @@ msgid " * Required build-dependency "
 msgstr ""
 
 #: debbuild:1650
-msgid " * Warning: "
+msgid " * Warning:  "
 msgstr ""
 
 #: debbuild:1261
@@ -79,11 +79,11 @@ msgid " with --rebuild\n"
 msgstr ""
 
 #: debbuild:464
-msgid "! Ignoring.\n"
+msgid "!  Ignoring.\n"
 msgstr ""
 
 #: debbuild:907
-msgid "%autosetup: option '-S "
+msgid "%autosetup:  option '-S "
 msgstr ""
 
 #: debbuild:558
@@ -104,11 +104,11 @@ msgid "', continuing\n"
 msgstr ""
 
 #: debbuild:1822
-msgid "'. Aborting!"
+msgid "'.  Aborting!"
 msgstr ""
 
 #: debbuild:512
-msgid ") barfed: "
+msgid ") barfed:  "
 msgstr ""
 
 #: debbuild:1657
@@ -121,12 +121,12 @@ msgstr ""
 
 #: debbuild:616
 #, perl-format
-msgid ". Missing %if.\n"
+msgid ".  Missing %if.\n"
 msgstr ""
 
 #: debbuild:633
 #, perl-format
-msgid ". Missing %if/%else.\n"
+msgid ".  Missing %if/%else.\n"
 msgstr ""
 
 #: debbuild:179
@@ -245,7 +245,7 @@ msgstr ""
 
 #: debbuild:629
 #, perl-format
-msgid "Unmatched %else at end of file. Missing %endif.\n"
+msgid "Unmatched %else at end of file.  Missing %endif.\n"
 msgstr ""
 
 #: debbuild:615
@@ -260,12 +260,12 @@ msgstr ""
 
 #: debbuild:612
 #, perl-format
-msgid "Unmatched %if at end of file. Missing %else/%endif.\n"
+msgid "Unmatched %if at end of file.  Missing %else/%endif.\n"
 msgstr ""
 
 #: debbuild:886
 #, perl-format
-msgid "Unmatched %if at end of file. Missing %endif.\n"
+msgid "Unmatched %if at end of file.  Missing %endif.\n"
 msgstr ""
 
 #: debbuild:771 debbuild:856
@@ -273,7 +273,7 @@ msgid "Upgrading relationship to Requires:.\n"
 msgstr ""
 
 #: debbuild:463
-msgid "WARNING: missing value for macro "
+msgid "WARNING:  Missing value for macro "
 msgstr ""
 
 #: debbuild:762 debbuild:769 debbuild:854 debbuild:861 debbuild:869
@@ -285,7 +285,7 @@ msgid "Warning:  Debian-specific '"
 msgstr ""
 
 #: debbuild:1299
-msgid "Warning: symlinking manpage failed: "
+msgid "Warning:  symlinking manpage failed:  "
 msgstr ""
 
 #: debbuild:1505


### PR DESCRIPTION
@Conan-Kudo thanks for the translation badge.  I've noticed the warnings about the spacing discrepancies, hence this PR.

See [Wikipedia](https://en.wikipedia.org/wiki/History_of_sentence_spacing) for details of differences between English and French; German also uses single spaces between sentences.