### PR TITLE
Install Ukrainian translation module.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -53,3 +53,5 @@ install:
 
 	install -d $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES
 	$(MSGFMT) po/de/debbuild.po -o $(DESTDIR)$(DATADIR)/locale/de/LC_MESSAGES/debbuild.mo
+	install -d $(DESTDIR)$(DATADIR)/locale/uk/LC_MESSAGES
+	$(MSGFMT) po/uk/debbuild.po -o $(DESTDIR)$(DATADIR)/locale/uk/LC_MESSAGES/debbuild.mo

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -84,6 +84,7 @@ make
 %{debconfigdir}/
 %{_sysconfdir}/debbuild/
 %{_datadir}/locale/de/LC_MESSAGES/debbuild.mo
+%{_datadir}/locale/uk/LC_MESSAGES/debbuild.mo
 
 %changelog
 * Fri Nov 22 2019 Neal Gompa <ngompa13@gmail.com>


### PR DESCRIPTION
Cool, this is the output of `LANGUAGE=uk debbuild -ba -v -S git_am SPECS/debbuild.spec`:
```
Це debbuild, версія 20.01.0
Виконуємо (%prep): /bin/sh -e /var/tmp/deb-tmp.prep.37764
Виконуємо (%build): /bin/sh -e /var/tmp/deb-tmp.build.29943
checking for pod2man... pod2man
checking for msgfmt... msgfmt
checking for /etc/os-release... yes
Reading Makefile.in...
Substituting the following values:
  msgfmt=msgfmt
  localedir=/usr/share/locale
  pod2man=pod2man
  datadir=/usr/share
  bindir=/usr/bin
  exec-prefix=/usr
  version=20.01.0
  libdir=/usr/lib/x86_64-linux-gnu
  sysconfdir=/etc
  datarootdir=/usr/share
  libexecdir=/usr/libexec
  debconfigdir=/usr/lib/debbuild
  exec_prefix=/usr
  mandir=/usr/share/man
  prefix=/usr
Writing Makefile...
Done.
cp debbuild debbuild.out
echo "\
version:20.01.0\n\
debconfigdir:/usr/lib/debbuild\n\
sysconfdir:/etc\n" >> debbuild.out
chmod +x debbuild.out
Виконуємо (%install): /bin/sh -e /var/tmp/deb-tmp.install.35133
rm -rf /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64
install -d /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/bin
install debbuild.out /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/bin/debbuild
install -d /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild
install -m 644 macros/macros.in /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild/macros
install -m 644 config/debrc /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild
install -m 755 scripts/find-lang.pl /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild
install -d /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild/macros.d
install -m 644 macros/macros.sysutils /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild/macros.d
install -m 644 macros/macros.texlive /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild/macros.d
install -m 644 macros/platform.in /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/lib/debbuild/macros.d/macros.00platform
install -d /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/etc/debbuild
install -d /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/share/man/man8
pod2man --utf8 --center="System Manager's Manual" --section 8 \
	--release="Release 20.01.0" debbuild \
	/home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/share/man/man8/debbuild.8
install -d /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/share/locale/de/LC_MESSAGES
msgfmt po/de/debbuild.po -o /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/share/locale/de/LC_MESSAGES/debbuild.mo
install -d /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/share/locale/uk/LC_MESSAGES
msgfmt po/uk/debbuild.po -o /home/andreas/Work/rpm/BUILDROOT/debbuild-20.01.0-0ubuntu18.04.amd64/usr/share/locale/uk/LC_MESSAGES/debbuild.mo
Перевіряємо залежності бібліотеки...
Виконуємо (package-creation): /bin/sh -e /var/tmp/deb-tmp.pkg.78837 for debbuild
dpkg-deb: building package 'debbuild' in '/home/andreas/Work/rpm/DEBS/all/debbuild_20.01.0-0ubuntu18.04_all.deb'.
Виконуємо (%clean): /bin/sh -e /var/tmp/deb-tmp.clean.59751
Записано пакунок із початковим кодом debbuild-20.01.0-0ubuntu18.04.sdeb in /home/andreas/Work/rpm/SDEBS.
Записано двійковий пакунок debbuild_20.01.0-0ubuntu18.04_all.deb in /home/andreas/Work/rpm/DEBS/all
```