### PR TITLE
OS-specific macros in lsb_detection

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -344,6 +344,9 @@ sub lsb_detection {
         _("Sorry, I quit.\n");
   }
 
+  # if our OS does not have a version, set it to some "unreleased" value
+  $basever //= "9999";
+
   # rpmbuild expects either integers or strings, and some distros (*cough*Ubuntu*cough*)
   # have versions that get interpreted as strings, which creates comparison problems.
   # This will make sure it's an integer to remain compatible.
@@ -351,8 +354,11 @@ sub lsb_detection {
 
   # Set some legacy globals & the standard generic OS-class globals;
   $specglobals{debdist} = $basecodename;
-  $specglobals{debver} = $specglobals{$baseos}
-    = $specglobals{$baseos.'_version'} = $specbasever;
+  $specglobals{debver} = $specbasever;
+  # the OS-class globals shall be overridable from .debmacros, so only set them if they are not yet
+  $specglobals{$baseos} //= $specbasever;
+  # if the basever does not have a sub-version, it needs to be multiplied by 100
+  $specglobals{$baseos.'_version'} //= $basever =~ /\./ || $basever eq "9999" ? $specbasever : $basever * 100;
 
   # Default %{dist} to something marginally sane.  Note this should be overrideable by --define.
   # This has been chosen to most closely follow the usage in RHEL/CentOS and Fedora, ie "el5" or "fc20".

--- a/t/003_baseosver.t
+++ b/t/003_baseosver.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use File::Basename;
+
+use Test::More tests => 4;
+
+my $scriptdir = dirname(__FILE__);
+
+my $home = $ENV{HOME};
+
+my $os_id = `cat /etc/os-release`;
+$os_id =~ /^ID="?(\w+)"?/m;
+$os_id = $1;
+
+my $os_seen = `./debbuild.out --showrc`;
+like($os_seen, qr/^%\Q$os_id\E ==> (\S+)/m, "os-release ID present");
+
+my $testdir = $scriptdir . '/../testdir/baseosver';
+local $ENV{HOME} = $testdir;
+open my $f, '>', "$testdir/.debmacros" || die "Could not write test file .debmacros: $!";
+print $f "%$os_id somethingsilly\n";
+close $f;
+
+my $test_os_seen = `./debbuild.out --showrc`;
+$test_os_seen =~ /^%\Q$os_id\E ==> (\S+)/m;
+is($1, "somethingsilly", ".debmacros overwrites /etc/os-release");
+
+TODO: {
+    todo_skip "make different /etc/os-release testable", 2;
+
+    local $ENV{HOME} = $testdir . '/debian10';
+    my $test_os_release = `./debbuild.out --showrc`;
+    like($test_os_release, qr/^%debian_version 1000/m, "Debian 10.0 is picked up from os-release");
+
+    local $ENV{HOME} = $testdir . '/debian_sid';
+    $test_os_release = `./debbuild.out --showrc`;
+    like($test_os_release, qr/^%debian_version 9999/m, "Debian sid is substituted");
+}

--- a/testdir/baseosver/debian10/os-release
+++ b/testdir/baseosver/debian10/os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 10 (buster)"
+NAME="Debian GNU/Linux"
+VERSION_ID="10"
+VERSION="10 (buster)"
+VERSION_CODENAME=buster
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/testdir/baseosver/debian_sid/os-release
+++ b/testdir/baseosver/debian_sid/os-release
@@ -1,0 +1,6 @@
+PRETTY_NAME="Debian GNU/Linux bullseye/sid"
+NAME="Debian GNU/Linux"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
- Do not overwrite OS-specific macros from lsb_detection if they are
  defined in .debmacros

- Correctly multiply Debian version to create %debian_version

Fixes #157