### PR TITLE
Dynamic detection of ISO-639-1 locale codes.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -10,6 +10,8 @@ MSGFMT = @MSGFMT@
 
 VERSION = @VERSION@
 
+LANGUAGES = $(shell ls po --hide=*.pot)
+
 .DEFAULT_GOAL := build
 .PHONY: build
 build: debbuild.out
@@ -51,7 +53,7 @@ install:
 		--release="Release $(VERSION)" debbuild \
 		$(DESTDIR)$(MANDIR)/man8/debbuild.8
 
-	for lang in de it tr uk ; do \
+	for lang in $(LANGUAGES) ; do \
 		install -d $(DESTDIR)$(DATADIR)/locale/$$lang/LC_MESSAGES ; \
 		$(MSGFMT) po/$$lang/debbuild.po -o $(DESTDIR)$(DATADIR)/locale/$$lang/LC_MESSAGES/debbuild.mo ; \
 	done

--- a/Makefile.in
+++ b/Makefile.in
@@ -10,7 +10,7 @@ MSGFMT = @MSGFMT@
 
 VERSION = @VERSION@
 
-LANGUAGES = $(shell ls po --hide=*.pot)
+LANGUAGES = @LANGUAGES@
 
 .DEFAULT_GOAL := build
 .PHONY: build

--- a/configure
+++ b/configure
@@ -24,6 +24,7 @@ Getopt::Long::GetOptions(\%options,
   'libdir:s',
   'datarootdir:s',
   'datadir:s',
+  'languages:s',
   'localedir:s',
   'mandir:s',
   'debconfigdir:s',
@@ -67,6 +68,12 @@ if (-e '/etc/os-release') {
     die "ERROR: Unable to find os-release or lsb_release. $0 failed.\n";
   }
 }
+
+print "Checking installable translations...";
+chomp(my $languages = qx(ls po --hide=*.pot));
+$languages =~ s/\s+/ /g;
+print "$languages\n";
+$options{'languages'} //= $languages;
 
 my $in_filename = 'Makefile.in';
 print "Reading $in_filename...\n";


### PR DESCRIPTION
Maybe this can come from `configure`? – Yep!