### PR TITLE
Add support for gems as source files

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1040,6 +1040,12 @@ sub unpackcmd {
       $sourcedrop =~ /\.tar$/ ? # plain .tar files don't need to be uncompressed
          '%{__tar} -x'.( $quietunpack ? '' : 'vv' ).'f '.
          "'%{_sourcedir}/$sourcedrop'" :
+      # .gem files are unpacked with different flags and need a gemspec generated
+      $sourcedrop =~ /\.gem$/ ?
+         '%{__gem} unpack '.( $quietunpack ? '--quiet --silent ' : '-V ' ).
+         "'%{_sourcedir}/$sourcedrop'\n".
+         "%{__gem} spec '%{_sourcedir}/$sourcedrop' --ruby > ".
+         "'./${sourcedrop}spec'" :
       decompress("%{_sourcedir}/$sourcedrop").
           ' | %{__tar} -x'.( $quietunpack ? '' : 'vv' ).'f -' ).$check_status;
 } # end unpackcmd()

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -33,11 +33,13 @@ Requires:       lsb-release
 Requires:       xz-utils
 Recommends:     dpkg-sig
 Suggests:       rpm
+Suggests:       ruby
 %else
 BuildRequires:  perl-generators
 BuildRequires:  perl(Pod::Man)
 Requires:       perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 Requires:       xz
+Suggests:       rubygems
 %endif
 
 BuildRequires:  gettext

--- a/macros/macros.in
+++ b/macros/macros.in
@@ -36,6 +36,7 @@
 %__echo			/bin/echo
 %__fakeroot		/usr/bin/fakeroot
 %__find			/usr/bin/find
+%__gem			/usr/bin/gem
 %__gpg			/usr/bin/gpg2
 %__gzip			/bin/gzip
 %__id			/usr/bin/id


### PR DESCRIPTION
Currently, it's not possible to use a gem as a source file like in
other tools such as rpmbuild. This means that the source can't be
obtained from rubygems.org, which is often desirable, and separate
deb-specific logic is required when packaging gems for both deb and
rpm-based systems. This adds support for using .gem files directly.