### PR TITLE
Remove --silent flag from gem unpack call

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1042,7 +1042,7 @@ sub unpackcmd {
          "'%{_sourcedir}/$sourcedrop'" :
       # .gem files are unpacked with different flags and need a gemspec generated
       $sourcedrop =~ /\.gem$/ ?
-         '%{__gem} unpack '.( $quietunpack ? '--quiet --silent ' : '-V ' ).
+         '%{__gem} unpack '.( $quietunpack ? '--quiet ' : '-V ' ).
          "'%{_sourcedir}/$sourcedrop'\n".
          "%{__gem} spec '%{_sourcedir}/$sourcedrop' --ruby > ".
          "'./${sourcedrop}spec'" :


### PR DESCRIPTION
Currently, this fails on distributions that ship older versions of Ruby,
such as Ubuntu 16.04, because the silent flag was introduced later.
Because we still need to support those distros, remove the usage here.