### PR TITLE
Fix arch/OS conditional statement translation to generate well-formed ones

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -568,12 +568,12 @@ LINE: while (<$fh>) {
 
     # RPM conditionals - transform to generic form
     if (s/^\s*%if(arch|os)\s+//) {
-      my @args = map { "%{_$1}==$_" } split /[\s,]+/;
-      $_ = '%if ' . join '||', @args;
+      my @args = map { " '%{_$1}' == '$_'" } split /[\s,]+/;
+      $_ = '%if ' . join ' || ', @args;
     }
     if (s/^\s*%ifn(arch|os)\s+//) {
-      my @args = map { "%{_$1}!=$_" } split /[\s,]+/;
-      $_ = '%if ' . join '&&', @args;
+      my @args = map { "'%{_$1}' != '$_'" } split /[\s,]+/;
+      $_ = '%if ' . join ' && ', @args;
     }
 
     # Generic %if..%else..%endif construct


### PR DESCRIPTION
For handling architecture and operating system conditionals, we
translate them into the generic form first before processing.
However, we have been incorrectly formatting these translated
conditionals, so the rest of the evaluation fails.

This change fixes it so that it is translated to the proper generic
form as expected by the conditional handling code.