### PR TITLE
Fix detection of subpackage naming format

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -685,7 +685,7 @@ ENDIF: if (/^\s*%endif/) {
       }
       if ($n) {       # Magic to add entries to the right package
         my $tmp = expandmacros($n);
-        $subname = /-n/ ? $tmp : "$pkgdata{main}{name}-$tmp";
+        $subname = /\s-n\s/ ? $tmp : "$pkgdata{main}{name}-$tmp";
       }
       if ($f) {
         $files_files{$subname} = $f;
@@ -696,7 +696,7 @@ ENDIF: if (/^\s*%endif/) {
       $stage = $1;
       # Magic to add entries to the right package
       my $tmp = expandmacros($2);
-      $subname = /-n/ ? $tmp : "$pkgdata{main}{name}-$tmp";
+      $subname = /\s-n\s/ ? $tmp : "$pkgdata{main}{name}-$tmp";
       push @pkglist, $subname;
       # Hack the filename for the package into a Debian-tool-compatible format.  GRRRRRR!!!!!
       # Have I mentioned I hate Debian Policy?


### PR DESCRIPTION
In circumstances where a subpackage name had `-n` in it, debbuild
would incorrectly match on that and fail to put the expected prefix
for binary package names declared using the subpackage shorthand
form of `%package bar` such that `%package bar-nox` for source package
`foo` would make a package `bar-nox` instead of `foo-bar-nox`.

Fix this by ensuring that we match on `-n` used as an option by
checking also for a whitespace character immediately before and after,
as that is obviously not a package name if whitespace characters exist.