### PR TITLE
expandmacros: replace gobal macros one at time

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1842,7 +1842,7 @@ sub expandmacros {
   # Replace global macros
   while (m/%(\w+)/g) {
     my $macro = $1;
-    s/%$macro/%{$macro}/g if grep { $macro eq $_ }
+    s/%$macro(\W)/%{$macro}$1/g if grep { $macro eq $_ }
         qw(optflags getconfdir sources patches)
       or defined $specglobals{$macro}
       or defined $pkgdata{main}{$macro};


### PR DESCRIPTION
replacemacros() is looping all available macros in input, to convert
them to %{} syntax. The conversion used to use s///g, which causes all
instances to be replaced in one pass. This causes wrong replaces in some
cases. Consider following input:

%cmake
%cmake_build

When one replaces %cmake with %{cmake} with g flag, latter line would be
%{cmake}_build, causing wrong expansion to happen at later point.

This should fix #181 