### PR TITLE
expandmacros: replace global macro even as last thing of input

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1842,7 +1842,7 @@ sub expandmacros {
   # Replace global macros
   while (m/%(\w+)/g) {
     my $macro = $1;
-    s/%$macro/%{$macro}/g if grep { $macro eq $_ }
+    s/%$macro(\W|$)/%{$macro}$1/g if grep { $macro eq $_ }
         qw(optflags getconfdir sources patches)
       or defined $specglobals{$macro}
       or defined $pkgdata{main}{$macro};


### PR DESCRIPTION
This builds on top of pull request #187.

When using --eval to expand a macro, there likely will not be
anything after a macro. This allows macro check to match even
if input ends directly after macro.

The regex was suggested by @ascherer.

Fixes #181.