### PR TITLE
Expand macros before processing %if(arch|os)/%ifn(arch|os) stanzas

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -568,11 +568,13 @@ LINE: while (<$fh>) {
 
     # RPM conditionals - transform to generic form
     if (s/^\s*%if(arch|os)\s+//) {
-      my @args = map { " '%{_$1}' == '$_'" } split /[\s,]+/;
+      my $expanded_conditional = lc(expandmacros($_));
+      my @args = map { " '%{_$1}' == '$_'" } split(/[\s,]+/, $expanded_conditional);
       $_ = '%if ' . join ' || ', @args;
     }
     if (s/^\s*%ifn(arch|os)\s+//) {
-      my @args = map { "'%{_$1}' != '$_'" } split /[\s,]+/;
+      my $expanded_conditional = lc(expandmacros($_));
+      my @args = map { "'%{_$1}' != '$_'" } split(/[\s,]+/, $expanded_conditional);
       $_ = '%if ' . join ' && ', @args;
     }
 


### PR DESCRIPTION
The arch/os conditionals are special in that they take space separated
arguments and tokenize them to transform them into standard conditionals.

However, it's very common for architecture lists to be constructed
with macros. For example: `%ifarch %{64bit_arches}` may be valid
input with the assumption that `%64bit_arches` is defined earlier
in the spec file. And that macro may also include others that need
to be expanded. Previously, this hasn't worked and debbuild would
decompose this into `%if "%{_arch}" == "%{64bit_arches"`, which
would get evaluated later into a stanza that wouldn't match to anything.

With this change, debbuild now expands all macros *first* before
decomposing the conditional into standard conditionals for further
processing.