### PR TITLE
Address warning from debbuild.

### DIFF
--- a/debbuild.spec
+++ b/debbuild.spec
@@ -54,6 +54,7 @@ Requires:       patch
 Requires:       pax
 Requires:       perl
 
+%if "%{_vendor}" == "debbuild"
 Recommends:     git-core
 Recommends:     quilt
 Recommends:     unzip
@@ -61,6 +62,7 @@ Recommends:     zip
 Recommends:     zstd
 
 Recommends:     %{name}-lua-support
+%endif
 
 %description
 debbuild attempts to build Debian-friendly semi-native packages from


### PR DESCRIPTION
Do we still need this? rpmbuild seems to grok **Recommends:** just fine.