### PR TITLE
Fix the usrmerge handling to work properly on Ubuntu 24 and Debian 12

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1895,6 +1895,16 @@ sub checkbuildreq {
 } # end checkbuildreq()
 
 
+## dpkg_query_paths(path)
+# Find out which package provides a given file.
+sub dpkg_query_paths {
+  my $req = shift;
+  return unless $req; # possibly empty
+  print _("Checking for ").$req._(" in installed packages...\n") if defined $specglobals{verbose};
+  my ($first) = qx($specglobals{__dpkg_query} -S $req) =~ /^([\w+-.]+?):/m;
+  return $first;
+} # end dpkg_query_paths()
+
 ## getreqs()
 # Find out which libraries/packages are required for any
 # executables and libs in a given file tree.
@@ -1922,7 +1932,7 @@ sub getreqs {
   # handle the case where the lib gets stuffed into a subpackage.  :/
   my @intprovlist = qx ( $specglobals{__find} $pkgtree -type f -name "*.so*" -printf "%P\n" );
 
-  my $reqliblist;
+  my @liblist;
   foreach (@reqlist) {
     next if /not a dynamic executable/;
     next if /statically linked/;
@@ -1945,18 +1955,23 @@ sub getreqs {
     # looked-for lib may not have the full soname version. (ie, it may
     # "just" point to one of the symlinks that get created somewhere.)
     next if grep { /\b$req/ } @intprovlist;
-    # workaround for Ubuntu usrmerge, resolve symlinks
-    $req = "*$req" if $req =~ m|^/lib| && "/usr/lib" eq (abs_path("/lib") || "");
 
-    $reqliblist .= " $req";
+    # workaround for Ubuntu usrmerge, resolve symlinks
+    # Firsly, we try to resolve dpkg path without modifications, then if it
+    # fails, we try to resolve it with /usr prefix (when /lib is a symlink to /usr/lib)
+    my $lib = dpkg_query_paths($req);
+    if(not(defined($lib)) && $req =~ m|^/lib| && "/usr/lib" eq (abs_path("/lib") || "")){
+      $lib = dpkg_query_paths("/usr$req");
+    }
+
+    if(not(defined($lib))){
+      warn _("Warning:  ").$req._(" not found in any package.\n");
+    }else{
+      push(@liblist, $lib);
+    }
   }
 
-# For now, we're done.  We're not going to meddle with versions yet.
-# Among other things, it's messier than handling "simple" yes/no "do
-# we have this lib?" deps.  >:(
-
-  return unless $reqliblist; # possibly empty
-  return map { m/^([\w+-.]+?):/ } qx($specglobals{__dpkg_query} -S$reqliblist);
+  return @liblist;
 } # end getreqs()
 
 

--- a/debbuild
+++ b/debbuild
@@ -1946,7 +1946,7 @@ sub getreqs {
     # "just" point to one of the symlinks that get created somewhere.)
     next if grep { /\b$req/ } @intprovlist;
     # workaround for Ubuntu usrmerge, resolve symlinks
-    $req = "/usr$req" if $req =~ m|^/lib| && "/usr/lib" eq (readlink "/lib" || "");
+    $req = "*$req" if $req =~ m|^/lib| && "/usr/lib" eq (abs_path("/lib") || "");
 
     $reqliblist .= " $req";
   }


### PR DESCRIPTION
Closes https://github.com/debbuild/debbuild/issues/254.

`debbuild` has some problems on Ubuntu 24.04 and Debian 12 with parsing package requirements. 

### Ubuntu 24.04
On Ubuntu 24.04, the problems were caused because of usage of `readlink` which was returning `usr/lib` (without quotes) when queried with argument `"/lib"`, while the expected return was `/usr/lib`. Changed `readlink` to `abs_path` from `Cwd` to prevent any possible future issues with that.

### Debian 12
On Debian 12, additionally were problems with `libc.so.6`, to be more exact -- `dpkg-query -S libc.so.6` is returning `/lib/x86_64-linux-gnu/libc.so.6`, while for all of the other libraries the prefix is `/usr/lib`. According to [dpkg specifications](https://man7.org/linux/man-pages/man1/dpkg-query.1.html), when the query starts with `/`, `dpkg-query -S` queries argument as a path, while in other cases it is queried as a substring. 

The issue was fixed by replacing prepended prefix `/usr` with `*` in case when path starts with `/lib` and `/lib` is a link to `/usr/lib`, which led to parsing prefix `/lib` as `*/lib`, so both possible variants of paths in `dpkg database` (I mean `/usr/lib` and `/lib`) are parsed correctly within one query.