### PR TITLE
Use %_debbuild instead of vendor for debbuild conditionals

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -133,7 +133,8 @@ parse_cmd();
 my $build_shell = expandmacros('%{___build_shell}');
 
 print version() if defined $specglobals{verbose};
-$specglobals{_debbuild} = $static_config{version};
+$specglobals{_debbuild} = 1;
+$specglobals{_debbuild_version} = $static_config{version};
 $specglobals{_debbuild_lua} = $lua_ver if defined($lua_ver);
 print "Lua: ".($lua_present ? $lua_ver : _('No Lua module loaded'))."\n"
       if $specglobals{verbose};

--- a/debbuild.spec
+++ b/debbuild.spec
@@ -13,7 +13,7 @@ Name:           debbuild
 Summary:        Build Debian-compatible .deb packages from RPM .spec files
 Version:        24.12.0
 Release:        0%{?dist}
-%if "%{_vendor}" == "debbuild"
+%if 0%{?_debbuild:1}
 Packager:       debbuild developers <https://github.com/debbuild/debbuild>
 Group:          devel
 %else
@@ -24,7 +24,7 @@ URL:            https://github.com/debbuild/debbuild
 Source:         %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-%if "%{_vendor}" == "debbuild"
+%if 0%{?_debbuild:1}
 BuildRequires:  podlators-perl
 BuildRequires:  lsb-release
 Requires:       liblocale-gettext-perl
@@ -70,7 +70,7 @@ should be able to interpret most spec files usefully.
 %package lua-support
 Summary:        Lua macro support for debbuild
 Requires:       %{name} = %{version}-%{release}
-%if "%{_vendor}" == "debbuild"
+%if 0%{?_debbuild:1}
 Requires:       liblua-api-perl
 %else
 Requires:       perl(Lua::API)


### PR DESCRIPTION
Distros are meant to set the vendor, not the tool. So if debbuild gets included in a distribution it may have a different vendor than 'debbuild'. Rpm doesn't have rpm as vendor either after all. Debian for example defines _vendor as "debian" for rpmbuild. The internal _debbuild macro is set to the version of debbuild so seems like a good way to identify the tool