### PR TITLE
PR #255: Why not look in absolute path?

### DIFF
--- a/debbuild
+++ b/debbuild
@@ -1957,13 +1957,7 @@ sub getreqs {
     next if grep { /\b$req/ } @intprovlist;
 
     # workaround for Ubuntu usrmerge, resolve symlinks
-    # Firsly, we try to resolve dpkg path without modifications, then if it
-    # fails, we try to resolve it with /usr prefix (when /lib is a symlink to /usr/lib)
-    my $lib = dpkg_query_paths($req);
-    if(not(defined($lib)) && $req =~ m|^/lib| && "/usr/lib" eq (abs_path("/lib") || "")){
-      $lib = dpkg_query_paths("/usr$req");
-    }
-
+    my $lib = dpkg_query_paths(abs_path($req));
     if(not(defined($lib))){
       warn _("Warning:  ").$req._(" not found in any package.\n");
     }else{


### PR DESCRIPTION
This PR improves on PR https://github.com/debbuild/debbuild/pull/255 on (K)Ubuntu and possibly Debian systems.

For whatever reason, `dpkg-query` does not seem to have an option to follow symlinked paths on its own. System stuff like `libc.so.6` is located under path `/usr/lib`, which is symlinked to path `/lib`.

By replacing the absolute path of such library files, we can skip the double invocation of `dpkg_query_paths` and the quite involved resolution to the same result (including a call to `abs_path` at that).

This PR was developed on **Kubuntu 24.04.1 LTS** with **debbuild 24.12.0** with example package [mmix.spec](https://github.com/ascherer/mmix/blob/local/mmix.spec).