### PR TITLE
Update pot and po files

### DIFF
--- a/po/de/debbuild.po
+++ b/po/de/debbuild.po
@@ -1,15 +1,15 @@
 # International version of DEBBUILD.
-# Copyright (C) 2018, 2020 Andreas Scherer
+# Copyright (C) 2018,2020,2025 Andreas Scherer
 # This file is distributed under the same license as the DEBBUILD package.
-# Andreas Scherer <andreas_github@freenet.de>, 2020.
 # Tobias Weise <tobias.weise@web.de>, 2020.
+# Andreas Scherer <andreas_github@freenet.de>, 2025.
 msgid ""
 msgstr ""
-"Project-Id-Version: DEBBUILD I18N 1.3\n"
+"Project-Id-Version: DEBBUILD 24.12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-22 13:12+0100\n"
-"PO-Revision-Date: 2020-09-26 23:29+0000\n"
-"Last-Translator: Tobias Weise <tobias.weise@web.de>\n"
+"POT-Creation-Date: 2025-02-08 17:19+0100\n"
+"PO-Revision-Date: 2025-02-08 17:19+0100\n"
+"Last-Translator: Andreas Scherer <andreas_github@freenet.de>\n"
 "Language-Team: German <https://translate.fedoraproject.org/projects/debbuild/"
 "master/de/>\n"
 "Language: de\n"
@@ -19,97 +19,118 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2.2\n"
 
-#: debbuild:1624
+#: debbuild:1624 debbuild:1827
 msgid "  Continuing anyway.\n"
 msgstr "  Fahre trotzdem fort.\n"
 
-#: debbuild:1623
+#: debbuild:1623 debbuild:1826
 msgid "  Required for successful build:\n"
 msgstr " Erforderlich für erfolgreiches Bauen:\n"
 
-#: debbuild:1682
+#: debbuild:1682 debbuild:1885
 msgid " * Conflicting build-dependency "
 msgstr " * Widersprechende Bau-Abhängigkeit "
 
-#: debbuild:1640 debbuild:1667
+#: debbuild:1640 debbuild:1667 debbuild:1843 debbuild:1870
 msgid " * Missing build-dependency "
 msgstr " * Fehlende Bau-Abhängigkeit "
 
-#: debbuild:1661
+#: debbuild:1661 debbuild:1864
 msgid " * Required build-dependency "
 msgstr " * Notwendige Bau-Abhängigkeit "
 
-#: debbuild:1656
+#: debbuild:1656 debbuild:1859
 msgid " * Warning:  "
 msgstr " * Warnung:  "
 
-#: debbuild:1267
+#: debbuild:1267 debbuild:1402
 msgid " failed (%"
 msgstr " gescheitert (%"
 
-#: debbuild:1509 debbuild:1519
+#: debbuild:1509 debbuild:1519 debbuild:1708 debbuild:1718
 msgid " for "
 msgstr " für "
 
-#: debbuild:446
+#: debbuild:446 debbuild:504
 msgid " for option '-"
 msgstr " für Option '-"
 
-#: debbuild:470 debbuild:1512 debbuild:1522 debbuild:1605
+#: debbuild:470 debbuild:1512 debbuild:1522 debbuild:1605 debbuild:528
+#: debbuild:1711 debbuild:1721 debbuild:1808
 msgid " in "
 msgstr " in "
 
-#: debbuild:1662
+#: debbuild:1902
+msgid " in installed packages...\n"
+msgstr " in installierten Paketen...\n"
+
+#: debbuild:1662 debbuild:1865
 msgid " is installed, but wrong version ("
 msgstr " ist installiert, hat aber falsche Version ("
 
-#: debbuild:1657
+#: debbuild:1657 debbuild:1860
 msgid " is probably installed but seems to be a virtual package.\n"
 msgstr " ist wohl installiert, scheint aber ein virtuelles Paket zu sein.\n"
 
-#: debbuild:1622
+#: debbuild:1961
+msgid " not found in any package.\n"
+msgstr " in keinem Paket gefunden.\n"
+
+#: debbuild:1622 debbuild:1825
 msgid " not found.  Can't check build-deps.\n"
 msgstr " nicht gefunden. Kann Bau-Abhängigkeiten nicht prüfen.\n"
 
-#: debbuild:565
+#: debbuild:565 debbuild:651
 msgid " of "
 msgstr " von "
 
-#: debbuild:496
+#: debbuild:1256 debbuild:1390
+msgid " script file "
+msgstr " Script-Datei "
+
+#: debbuild:496 debbuild:554
 msgid " stage.  Ignoring.\n"
 msgstr " Stufe. Ignoriert.\n"
 
-#: debbuild:1771
+#: debbuild:1771 debbuild:1979
 #, perl-brace-format
 msgid " to %{_topdir}.\n"
 msgstr " nach %{_topdir}.\n"
 
-#: debbuild:451
+#: debbuild:451 debbuild:509
 msgid " with --rebuild\n"
 msgstr " mit --rebuild\n"
 
-#: debbuild:470
+#: debbuild:470 debbuild:528
 msgid "!  Ignoring.\n"
 msgstr "! Ignoriert.\n"
 
-#: debbuild:913
+#: debbuild:2504
+msgid "# end of the ommited macro"
+msgstr "# Ende des fehlenden Makros"
+
+#: debbuild:913 debbuild:1030
 msgid "%autosetup:  option '-S "
 msgstr "%autosetup: Option '-S "
 
-#: debbuild:564
+#: debbuild:564 debbuild:650
 msgid "' at line "
 msgstr "' in Zeile "
 
-#: debbuild:914
+#: debbuild:914 debbuild:1031
 msgid "' currently not supported at line "
 msgstr "' aktuell nicht unterstützt in Zeile "
+
+#: debbuild:1670 debbuild:1676
+msgid "' is not natively supported by .deb packages.\n"
+msgstr "' wird von .deb-Paketen nicht unterstützt.\n"
 
 #: debbuild:824
 #, perl-format
 msgid "'%exclude' keyword found, ignoring input line\n"
 msgstr "Schlüsselwort '%exclude' gefunden, Eingabezeile ignoriert\n"
 
-#: debbuild:981
+#: debbuild:981 debbuild:1098
 msgid "', continuing\n"
 msgstr "', setze fort\n"
 
@@ -117,106 +138,139 @@ msgstr "', setze fort\n"
 msgid "'.  Aborting!"
 msgstr "'. Abbruch!"
 
-#: debbuild:518
+#: debbuild:2466
+msgid "(error object is not a string)"
+msgstr "(Fehler: Objekt ist keine Zeichenkette)"
+
+#: debbuild:518 debbuild:587
 msgid ") barfed:  "
 msgstr ") schimpfte:  "
 
-#: debbuild:1663
+#: debbuild:1663 debbuild:1866
 msgid "):  Need "
 msgstr "): Benötige "
 
-#: debbuild:1621
+#: debbuild:1621 debbuild:1824
 msgid "**WARNING**  "
 msgstr "**WARNUNG**  "
 
-#: debbuild:622
+#: debbuild:622 debbuild:702
 #, perl-format
 msgid ".  Missing %if.\n"
 msgstr ". Fehlendes %if.\n"
 
-#: debbuild:639
+#: debbuild:639 debbuild:720
 #, perl-format
 msgid ".  Missing %if/%else.\n"
 msgstr ". Fehlendes %if/%else.\n"
 
-#: debbuild:179
+#: debbuild:179 debbuild:197
 msgid ":  build requirements not met.\n"
 msgstr ": Bau-Abhängigkeit nicht erfüllt.\n"
 
-#: debbuild:769 debbuild:776 debbuild:861 debbuild:876
+#: debbuild:769 debbuild:776 debbuild:861 debbuild:876 debbuild:866
+#: debbuild:873 debbuild:973 debbuild:988
 msgid ":' is not natively supported by .deb packages.\n"
 msgstr ":' wird von .deb-Paketen nicht unterstützt.\n"
 
-#: debbuild:868 debbuild:872
+#: debbuild:868 debbuild:872 debbuild:980 debbuild:984
 #, perl-format
 msgid ":' outside %if wrapper\n"
 msgstr ":' außerhalb eines %if-Blocks\n"
 
-#: debbuild:151
+#: debbuild:151 debbuild:169
 msgid "Can't --rebuild with "
 msgstr "Kein --rebuild möglich mit "
 
-#: debbuild:178
+#: debbuild:178 debbuild:196
 msgid "Can't build "
 msgstr "Kein Bau möglich von "
 
-#: debbuild:1057
+#: debbuild:1057 debbuild:1181
 msgid "Can't handle unknown file type '"
 msgstr "Nicht unterstützter Dateityp '"
 
-#: debbuild:1767
+#: debbuild:1767 debbuild:1975
 msgid "Can't install "
 msgstr "Nicht installierbar: "
 
-#: debbuild:1255
+#: debbuild:1255 debbuild:1389
 msgid "Can't open/create "
 msgstr "Öffnen/Erzeugen nicht möglich: "
 
-#: debbuild:450
+#: debbuild:450 debbuild:508
 msgid "Can't use -"
 msgstr "Nicht benutzbar: -"
 
-#: debbuild:495
+#: debbuild:495 debbuild:553
 msgid "Can't use --short-circuit for "
 msgstr "--short-circuit nicht verwendbar für "
 
-#: debbuild:1704
+#: debbuild:1902
+msgid "Checking for "
+msgstr "Prüfe auf "
+
+#: debbuild:1704 debbuild:1917
 msgid "Checking library requirements...\n"
 msgstr "Prüfe Bibliotheksabhängigkeiten...\n"
 
-#: debbuild:1346
+#: debbuild:1346 debbuild:1484
 msgid "Could not open: "
 msgstr "Nicht zu öffnen: "
 
-#: debbuild:770 debbuild:877
+#: debbuild:770 debbuild:877 debbuild:867 debbuild:989
 msgid "Downgrading relationship to Enhances:.\n"
 msgstr "Reduziere Abhängigkeit auf Enhances:.\n"
 
-#: debbuild:1267
+#: debbuild:1267 debbuild:1402
 msgid "Exec of "
 msgstr "Ausführung von "
 
-#: debbuild:1263
+#: debbuild:1263 debbuild:1398
 msgid "Executing ("
 msgstr "Ausführung von ("
 
-#: debbuild:1770
+#: debbuild:1770 debbuild:1978
 msgid "Extracted source package "
 msgstr "Entpacke Quellpaket "
 
-#: debbuild:1353
+#: debbuild:1353 debbuild:1491
 msgid "File not found: "
 msgstr "Datei nicht gefunden: "
+
+#: debbuild:2467
+msgid "Lua Error:"
+msgstr "Lua Fehler:"
+
+#: debbuild:2481
+msgid "Lua Error: Cannot create state!"
+msgstr "Lua Fehler: Kann Zustand nicht erzeugen!"
+
+#: debbuild:2495
+msgid "Lua Error: Unable to open Lua::API::State!"
+msgstr "Lua Fehler: Kann Lua::API::State nicht öffnen!"
+
+#: debbuild:2503
+msgid "Lua module not loaded! The following macro can't be expanded:"
+msgstr "Lua-Modul nicht geladen! Das folgende Makro kann nicht aufgelöst werden:"
+
+#: debbuild:1677
+msgid "Merging with 'post' script.\n"
+msgstr "Verbinde mit 'post'-Skript.\n"
+
+#: debbuild:1671
+msgid "Merging with 'pre' script.\n"
+msgstr "Verbinde mit 'pre'-Skript.\n"
 
 #: debbuild:1827
 msgid "Missing value for '%"
 msgstr "Fehlender Wert für '%"
 
-#: debbuild:343
+#: debbuild:343 debbuild:401
 msgid "No 'os-release' file or 'lsb_release' program found.\n"
 msgstr "Weder Datei 'os-release' noch Programm 'lsb_release' gefunden.\n"
 
-#: debbuild:516
+#: debbuild:516 debbuild:585
 msgid "No .spec file specified!  Exiting.\n"
 msgstr "Keine .spec-Datei angegeben! Abbruch.\n"
 
@@ -224,100 +278,106 @@ msgstr "Keine .spec-Datei angegeben! Abbruch.\n"
 msgid "No .spec file to work with!  Exiting.\n"
 msgstr "Keine .spec-Datei zur Bearbeitung! Abbruch.\n"
 
-#: debbuild:161
+#: debbuild:138
+msgid "No Lua module loaded"
+msgstr "Kein Lua-Moul geladen"
+
+#: debbuild:161 debbuild:179
 msgid "No tarfile specified!  Exiting.\n"
 msgstr "Keine Archivdatei angegeben! Abbruch.\n"
 
-#: debbuild:1521
+#: debbuild:1521 debbuild:1720
 msgid "Signed binary package "
 msgstr "Signiere Binärpaket "
 
-#: debbuild:344
+#: debbuild:344 debbuild:402
 msgid "Sorry, I quit.\n"
 msgstr "Tut mir leid, ich gebe auf.\n"
 
-#: debbuild:980
+#: debbuild:980 debbuild:1097
 #, perl-format
 msgid "Suspect %setup tag '%setup"
 msgstr "Verdächtige %setup-Zeile '%setup"
 
-#: debbuild:483
+#: debbuild:483 debbuild:541
 msgid "This is debbuild, version "
 msgstr "Dies ist DEBBUILD, Version "
 
-#: debbuild:1673
+#: debbuild:1673 debbuild:1876
 msgid "To install all missing dependencies, run 'apt install "
 msgstr "Installation aller fehlenden Abhängigkeiten mit 'apt install "
 
-#: debbuild:1687
+#: debbuild:1687 debbuild:1890
 msgid "To remove all conflicting dependencies, run 'apt remove "
 msgstr "Entfernung aller störenden Pakete mit 'apt remove "
 
-#: debbuild:445
+#: debbuild:445 debbuild:503
 msgid "Unknown stage "
 msgstr "Unbekannte Stufe "
 
-#: debbuild:564
+#: debbuild:564 debbuild:650
 msgid "Unknown tag '%"
 msgstr "Unbekannter Marker '%"
 
-#: debbuild:635
+#: debbuild:635 debbuild:715
 #, perl-format
 msgid "Unmatched %else at end of file.  Missing %endif.\n"
 msgstr "Nicht geschlossenes %else am Dateiende. Fehlendes %endif.\n"
 
-#: debbuild:621
+#: debbuild:621 debbuild:701
 #, perl-format
 msgid "Unmatched %else in line "
 msgstr "Einsames %else in Zeile "
 
-#: debbuild:638
+#: debbuild:638 debbuild:719
 #, perl-format
 msgid "Unmatched %endif in line "
 msgstr "Einsames %endif in Zeile "
 
-#: debbuild:618
+#: debbuild:618 debbuild:697
 #, perl-format
 msgid "Unmatched %if at end of file.  Missing %else/%endif.\n"
 msgstr "Nicht geschlossenes %if am Dateiende. Fehlendes %else/%endif.\n"
 
-#: debbuild:892
+#: debbuild:892 debbuild:1009
 #, perl-format
 msgid "Unmatched %if at end of file.  Missing %endif.\n"
 msgstr "Nicht geschlossenes %if am Dateiende. Fehlendes %endif.\n"
 
-#: debbuild:777 debbuild:862
+#: debbuild:777 debbuild:862 debbuild:874 debbuild:974
 msgid "Upgrading relationship to Requires:.\n"
 msgstr "Setze Abhängigkeit auf Requires:.\n"
 
-#: debbuild:469
+#: debbuild:469 debbuild:527
 msgid "WARNING:  Missing value for macro "
 msgstr "WARNUNG: Fehlender Wert für Makro "
 
+#: debbuild:1961
+msgid "Warning:  "
+msgstr "Warnung: '"
+
 #: debbuild:768 debbuild:775 debbuild:860 debbuild:867 debbuild:875
+#: debbuild:865 debbuild:872 debbuild:972 debbuild:979 debbuild:987
+#: debbuild:1669 debbuild:1675
 msgid "Warning:  '"
 msgstr "Warnung: '"
 
-#: debbuild:871
+#: debbuild:871 debbuild:983
 msgid "Warning:  Debian-specific '"
 msgstr "Warnung: Debian-eigenes '"
 
-#: debbuild:1305
+#: debbuild:1305 debbuild:1440
 msgid "Warning:  symlinking manpage failed:  "
 msgstr "Warnung: Kann Symlink für Manpage nicht setzen:  "
 
-#: debbuild:1511
+#: debbuild:1511 debbuild:1710
 msgid "Wrote binary package "
 msgstr "Fertig mit Binärpaket "
 
-#: debbuild:1605
+#: debbuild:1605 debbuild:1808
 msgid "Wrote source package "
 msgstr "Fertig mit Quellpaket "
 
-#: debbuild:1256
-msgid " script file "
-msgstr " Script-Datei "
-
-#: debbuild:517
+#: debbuild:517 debbuild:586
 msgid "specfile ("
 msgstr ".spec-Datei ("

--- a/po/debbuild.pot
+++ b/po/debbuild.pot
@@ -1,14 +1,14 @@
 # International version of DEBBUILD.
-# Copyright (C) 2018, 2020 Andreas Scherer
+# Copyright (C) 2018,2020,2025 Andreas Scherer
 # This file is distributed under the same license as the DEBBUILD package.
-# Andreas Scherer <andreas_github@freenet.de>, 2020.
+# Andreas Scherer <andreas_github@freenet.de>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: DEBBUILD I18N 1.3\n"
+"Project-Id-Version: DEBBUILD 24.12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-22 13:12+0100\n"
+"POT-Creation-Date: 2025-02-08 17:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,89 +17,110 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: debbuild:1624
+#: debbuild:1624 debbuild:1827
 msgid "  Continuing anyway.\n"
 msgstr ""
 
-#: debbuild:1623
+#: debbuild:1623 debbuild:1826
 msgid "  Required for successful build:\n"
 msgstr ""
 
-#: debbuild:1682
+#: debbuild:1682 debbuild:1885
 msgid " * Conflicting build-dependency "
 msgstr ""
 
-#: debbuild:1640 debbuild:1667
+#: debbuild:1640 debbuild:1667 debbuild:1843 debbuild:1870
 msgid " * Missing build-dependency "
 msgstr ""
 
-#: debbuild:1661
+#: debbuild:1661 debbuild:1864
 msgid " * Required build-dependency "
 msgstr ""
 
-#: debbuild:1656
+#: debbuild:1656 debbuild:1859
 msgid " * Warning:  "
 msgstr ""
 
-#: debbuild:1267
+#: debbuild:1267 debbuild:1402
 msgid " failed (%"
 msgstr ""
 
-#: debbuild:1509 debbuild:1519
+#: debbuild:1509 debbuild:1519 debbuild:1708 debbuild:1718
 msgid " for "
 msgstr ""
 
-#: debbuild:446
+#: debbuild:446 debbuild:504
 msgid " for option '-"
 msgstr ""
 
-#: debbuild:470 debbuild:1512 debbuild:1522 debbuild:1605
+#: debbuild:470 debbuild:1512 debbuild:1522 debbuild:1605 debbuild:528
+#: debbuild:1711 debbuild:1721 debbuild:1808
 msgid " in "
 msgstr ""
 
-#: debbuild:1662
+#: debbuild:1902
+msgid " in installed packages...\n"
+msgstr ""
+
+#: debbuild:1662 debbuild:1865
 msgid " is installed, but wrong version ("
 msgstr ""
 
-#: debbuild:1657
+#: debbuild:1657 debbuild:1860
 msgid " is probably installed but seems to be a virtual package.\n"
 msgstr ""
 
-#: debbuild:1622
+#: debbuild:1961
+msgid " not found in any package.\n"
+msgstr ""
+
+#: debbuild:1622 debbuild:1825
 msgid " not found.  Can't check build-deps.\n"
 msgstr ""
 
-#: debbuild:565
+#: debbuild:565 debbuild:651
 msgid " of "
 msgstr ""
 
-#: debbuild:496
+#: debbuild:1256 debbuild:1390
+msgid " script file "
+msgstr ""
+
+#: debbuild:496 debbuild:554
 msgid " stage.  Ignoring.\n"
 msgstr ""
 
-#: debbuild:1771
+#: debbuild:1771 debbuild:1979
 #, perl-brace-format
 msgid " to %{_topdir}.\n"
 msgstr ""
 
-#: debbuild:451
+#: debbuild:451 debbuild:509
 msgid " with --rebuild\n"
 msgstr ""
 
-#: debbuild:470
+#: debbuild:470 debbuild:528
 msgid "!  Ignoring.\n"
 msgstr ""
 
-#: debbuild:913
+#: debbuild:2504
+msgid "# end of the ommited macro"
+msgstr ""
+
+#: debbuild:913 debbuild:1030
 msgid "%autosetup:  option '-S "
 msgstr ""
 
-#: debbuild:564
+#: debbuild:564 debbuild:650
 msgid "' at line "
 msgstr ""
 
-#: debbuild:914
+#: debbuild:914 debbuild:1031
 msgid "' currently not supported at line "
+msgstr ""
+
+#: debbuild:1670 debbuild:1676
+msgid "' is not natively supported by .deb packages.\n"
 msgstr ""
 
 #: debbuild:824
@@ -107,7 +128,7 @@ msgstr ""
 msgid "'%exclude' keyword found, ignoring input line\n"
 msgstr ""
 
-#: debbuild:981
+#: debbuild:981 debbuild:1098
 msgid "', continuing\n"
 msgstr ""
 
@@ -115,106 +136,139 @@ msgstr ""
 msgid "'.  Aborting!"
 msgstr ""
 
-#: debbuild:518
+#: debbuild:2466
+msgid "(error object is not a string)"
+msgstr ""
+
+#: debbuild:518 debbuild:587
 msgid ") barfed:  "
 msgstr ""
 
-#: debbuild:1663
+#: debbuild:1663 debbuild:1866
 msgid "):  Need "
 msgstr ""
 
-#: debbuild:1621
+#: debbuild:1621 debbuild:1824
 msgid "**WARNING**  "
 msgstr ""
 
-#: debbuild:622
+#: debbuild:622 debbuild:702
 #, perl-format
 msgid ".  Missing %if.\n"
 msgstr ""
 
-#: debbuild:639
+#: debbuild:639 debbuild:720
 #, perl-format
 msgid ".  Missing %if/%else.\n"
 msgstr ""
 
-#: debbuild:179
+#: debbuild:179 debbuild:197
 msgid ":  build requirements not met.\n"
 msgstr ""
 
-#: debbuild:769 debbuild:776 debbuild:861 debbuild:876
+#: debbuild:769 debbuild:776 debbuild:861 debbuild:876 debbuild:866
+#: debbuild:873 debbuild:973 debbuild:988
 msgid ":' is not natively supported by .deb packages.\n"
 msgstr ""
 
-#: debbuild:868 debbuild:872
+#: debbuild:868 debbuild:872 debbuild:980 debbuild:984
 #, perl-format
 msgid ":' outside %if wrapper\n"
 msgstr ""
 
-#: debbuild:151
+#: debbuild:151 debbuild:169
 msgid "Can't --rebuild with "
 msgstr ""
 
-#: debbuild:178
+#: debbuild:178 debbuild:196
 msgid "Can't build "
 msgstr ""
 
-#: debbuild:1057
+#: debbuild:1057 debbuild:1181
 msgid "Can't handle unknown file type '"
 msgstr ""
 
-#: debbuild:1767
+#: debbuild:1767 debbuild:1975
 msgid "Can't install "
 msgstr ""
 
-#: debbuild:1255
+#: debbuild:1255 debbuild:1389
 msgid "Can't open/create "
 msgstr ""
 
-#: debbuild:450
+#: debbuild:450 debbuild:508
 msgid "Can't use -"
 msgstr ""
 
-#: debbuild:495
+#: debbuild:495 debbuild:553
 msgid "Can't use --short-circuit for "
 msgstr ""
 
-#: debbuild:1704
+#: debbuild:1902
+msgid "Checking for "
+msgstr ""
+
+#: debbuild:1704 debbuild:1917
 msgid "Checking library requirements...\n"
 msgstr ""
 
-#: debbuild:1346
+#: debbuild:1346 debbuild:1484
 msgid "Could not open: "
 msgstr ""
 
-#: debbuild:770 debbuild:877
+#: debbuild:770 debbuild:877 debbuild:867 debbuild:989
 msgid "Downgrading relationship to Enhances:.\n"
 msgstr ""
 
-#: debbuild:1267
+#: debbuild:1267 debbuild:1402
 msgid "Exec of "
 msgstr ""
 
-#: debbuild:1263
+#: debbuild:1263 debbuild:1398
 msgid "Executing ("
 msgstr ""
 
-#: debbuild:1770
+#: debbuild:1770 debbuild:1978
 msgid "Extracted source package "
 msgstr ""
 
-#: debbuild:1353
+#: debbuild:1353 debbuild:1491
 msgid "File not found: "
+msgstr ""
+
+#: debbuild:2467
+msgid "Lua Error:"
+msgstr ""
+
+#: debbuild:2481
+msgid "Lua Error: Cannot create state!"
+msgstr ""
+
+#: debbuild:2495
+msgid "Lua Error: Unable to open Lua::API::State!"
+msgstr ""
+
+#: debbuild:2503
+msgid "Lua module not loaded! The following macro can't be expanded:"
+msgstr ""
+
+#: debbuild:1677
+msgid "Merging with 'post' script.\n"
+msgstr ""
+
+#: debbuild:1671
+msgid "Merging with 'pre' script.\n"
 msgstr ""
 
 #: debbuild:1827
 msgid "Missing value for '%"
 msgstr ""
 
-#: debbuild:343
+#: debbuild:343 debbuild:401
 msgid "No 'os-release' file or 'lsb_release' program found.\n"
 msgstr ""
 
-#: debbuild:516
+#: debbuild:516 debbuild:585
 msgid "No .spec file specified!  Exiting.\n"
 msgstr ""
 
@@ -222,100 +276,106 @@ msgstr ""
 msgid "No .spec file to work with!  Exiting.\n"
 msgstr ""
 
-#: debbuild:161
+#: debbuild:138
+msgid "No Lua module loaded"
+msgstr ""
+
+#: debbuild:161 debbuild:179
 msgid "No tarfile specified!  Exiting.\n"
 msgstr ""
 
-#: debbuild:1521
+#: debbuild:1521 debbuild:1720
 msgid "Signed binary package "
 msgstr ""
 
-#: debbuild:344
+#: debbuild:344 debbuild:402
 msgid "Sorry, I quit.\n"
 msgstr ""
 
-#: debbuild:980
+#: debbuild:980 debbuild:1097
 #, perl-format
 msgid "Suspect %setup tag '%setup"
 msgstr ""
 
-#: debbuild:483
+#: debbuild:483 debbuild:541
 msgid "This is debbuild, version "
 msgstr ""
 
-#: debbuild:1673
+#: debbuild:1673 debbuild:1876
 msgid "To install all missing dependencies, run 'apt install "
 msgstr ""
 
-#: debbuild:1687
+#: debbuild:1687 debbuild:1890
 msgid "To remove all conflicting dependencies, run 'apt remove "
 msgstr ""
 
-#: debbuild:445
+#: debbuild:445 debbuild:503
 msgid "Unknown stage "
 msgstr ""
 
-#: debbuild:564
+#: debbuild:564 debbuild:650
 msgid "Unknown tag '%"
 msgstr ""
 
-#: debbuild:635
+#: debbuild:635 debbuild:715
 #, perl-format
 msgid "Unmatched %else at end of file.  Missing %endif.\n"
 msgstr ""
 
-#: debbuild:621
+#: debbuild:621 debbuild:701
 #, perl-format
 msgid "Unmatched %else in line "
 msgstr ""
 
-#: debbuild:638
+#: debbuild:638 debbuild:719
 #, perl-format
 msgid "Unmatched %endif in line "
 msgstr ""
 
-#: debbuild:618
+#: debbuild:618 debbuild:697
 #, perl-format
 msgid "Unmatched %if at end of file.  Missing %else/%endif.\n"
 msgstr ""
 
-#: debbuild:892
+#: debbuild:892 debbuild:1009
 #, perl-format
 msgid "Unmatched %if at end of file.  Missing %endif.\n"
 msgstr ""
 
-#: debbuild:777 debbuild:862
+#: debbuild:777 debbuild:862 debbuild:874 debbuild:974
 msgid "Upgrading relationship to Requires:.\n"
 msgstr ""
 
-#: debbuild:469
+#: debbuild:469 debbuild:527
 msgid "WARNING:  Missing value for macro "
 msgstr ""
 
+#: debbuild:1961
+msgid "Warning:  "
+msgstr ""
+
 #: debbuild:768 debbuild:775 debbuild:860 debbuild:867 debbuild:875
+#: debbuild:865 debbuild:872 debbuild:972 debbuild:979 debbuild:987
+#: debbuild:1669 debbuild:1675
 msgid "Warning:  '"
 msgstr ""
 
-#: debbuild:871
+#: debbuild:871 debbuild:983
 msgid "Warning:  Debian-specific '"
 msgstr ""
 
-#: debbuild:1305
+#: debbuild:1305 debbuild:1440
 msgid "Warning:  symlinking manpage failed:  "
 msgstr ""
 
-#: debbuild:1511
+#: debbuild:1511 debbuild:1710
 msgid "Wrote binary package "
 msgstr ""
 
-#: debbuild:1605
+#: debbuild:1605 debbuild:1808
 msgid "Wrote source package "
 msgstr ""
 
-#: debbuild:1256
-msgid " script file "
-msgstr ""
-
-#: debbuild:517
+#: debbuild:517 debbuild:586
 msgid "specfile ("
 msgstr ""


### PR DESCRIPTION
Run `xgettext --keyword=_ --language=Perl --sort-output --copyright-holder='Andreas Scherer' --package-name='DEBBUILD' --package-version=24.12.0 -j -o po/debbuild.pot debbuild` and `msgmerge po/de/debbuild.po po/debbuild.pot -o po/de/debbuild.po` and apply the usual spit and polish (German) to update the relevant files for transliteration.

Note that there's at least one typo (**ommited**) in the string pool of `debbuild`.  I do not have time to open a third PR to fix that. Nor for a fourth PR to update at least the skeletons of the many `.po` files for other languages.
