### PR TITLE
Fix typo in translatable string.

### DIFF
--- a/po/debbuild.pot
+++ b/po/debbuild.pot
@@ -104,7 +104,7 @@ msgid "!  Ignoring.\n"
 msgstr ""
 
 #: debbuild:2504
-msgid "# end of the ommited macro"
+msgid "# end of the omitted macro"
 msgstr ""
 
 #: debbuild:913 debbuild:1030


### PR DESCRIPTION
Yesterday I forgot to fix this typo in my `aspell` comitt. :smile: 